### PR TITLE
color legend entry

### DIFF
--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -75,7 +75,6 @@ function _Legend_(fg::FigureGrid)
     for key in [:row, :col, :layout, :stack, :dodge, :group]
         pop!(scales, key, nothing)
     end
-
     # if no legend-worthy keyword remains return nothing
     isempty(scales) && return nothing
 
@@ -88,6 +87,11 @@ function _Legend_(fg::FigureGrid)
     labels = Vector{String}[]
     elements_list = Vector{Vector{LegendElement}}[]
 
+    # search in attributes if a color is given for e.g. lines/scatter
+    legend_colors = unique([entry.attributes[:color] for entry in entries(grid) if haskey(entry.attributes, :color)])
+    # if a single agreeable color is found, use that for the Legend entries
+    legend_color = length(legend_colors) == 1 ? first(legend_colors) : nothing
+
     for title in titles
         label_attrs = [key for (key, val) in scales if val.label == title]
         uniquevalues = mapreduce(k -> datavalues(scales[k]), assert_equal, label_attrs)
@@ -97,6 +101,9 @@ function _Legend_(fg::FigureGrid)
                 shared_attrs = attrs ∩ label_attrs
                 isempty(shared_attrs) && continue
                 options = [attr => plotvalues(scales[attr])[idx] for attr in shared_attrs]
+                if !isnothing(legend_color)
+                    push!(options, :color => legend_color)
+                end
                 append!(elements, legend_elements(P; options...))
             end
             return elements


### PR DESCRIPTION
Legend currently doesn't pick up an e.g. markercolor:
```julia
df = (
    x = 1:10,
    y = rand(10),
    attr = ["m $i" for i in 1:10],
)
draw(data(df) * mapping(:x, :y, marker=:attr) * visual(Scatter, color=:red))
```
![image](https://user-images.githubusercontent.com/1010467/124783513-6a0e6d80-df45-11eb-8f3f-628180f533bb.png)


This PR takes uses the color, if it's a single color:
![image](https://user-images.githubusercontent.com/1010467/124783670-87dbd280-df45-11eb-9bfa-3f4a5ee49513.png)

if multiple colors are used, it defaults back to black:
```julia
draw(data(df) * (mapping(:x, :y, marker=:attr) * (visual(Scatter, color=:red, markersize=20) + visual(Scatter, color=:green, markersize=10))))
```
![image](https://user-images.githubusercontent.com/1010467/124783836-a4780a80-df45-11eb-9ac6-26df81ae981d.png)
