### PR TITLE
Run CompatHelper daily instead of weekly

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -2,7 +2,7 @@ name: CompatHelper
 
 on:
   schedule:
-    - cron: '00 * * * *'
+    - cron: '00 00 * * *'
   issues:
     types: [opened, reopened]
 


### PR DESCRIPTION
If CompatHelper runs daily instead of hourly it will clutter the GitHub Actions tab less with all kinds of runs.