### PR TITLE
Export Layers type

### DIFF
--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -27,7 +27,7 @@ import FileIO
 import RelocatableFolders
 
 export hideinnerdecorations!, deleteemptyaxes!
-export Layer, ProcessedLayer
+export Layer, Layers, ProcessedLayer
 export Entry, AxisEntries
 export renamer, sorter, nonnumeric, verbatim
 export density, histogram, linear, smooth, expectation, frequency


### PR DESCRIPTION
`Layer` and `ProcessedLayer` are already exported. Why not `Layers`?

I need this in order to store plots in a custom struct:
```julia
struct MyType
    p1::Layer
    p2::Layers
end
```