### PR TITLE
Support makie v0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi"]
-version = "0.6.12"
+version = "0.6.13"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -32,7 +32,7 @@ GeometryBasics = "0.4.1"
 GridLayoutBase = "0.6, 0.7, 0.8, 0.9"
 KernelDensity = "0.6"
 Loess = "0.5.1"
-Makie = "0.17.6, 0.18"
+Makie = "0.19"
 PlotUtils = "1"
 PooledArrays = "1"
 RelocatableFolders = "0.1, 0.2, 0.3, 1.0"

--- a/examples/gui.jl
+++ b/examples/gui.jl
@@ -20,7 +20,7 @@ function gui!(scene, layout, df)
     plot_options = [("none", nothing), ("scatter", Scatter), ("lines", Lines), ("barplot", BarPlot)]
     plot_menu = LMenu(scene, options = plot_options, textsize=30, width=500)
 
-    layout[1, 1] = Label(scene, "plot type", textsize=30)
+    layout[1, 1] = Label(scene, "plot type", fontsize=30)
     layout[1, 2] = plot_menu
 
     analysis_options = [("none", nothing), ("linear", linear), ("smooth", smooth),
@@ -28,7 +28,7 @@ function gui!(scene, layout, df)
 
     analysis_menu = LMenu(scene, options = analysis_options, textsize=30, width=500)
 
-    layout[2, 1] = Label(scene, "analysis", textsize=30)
+    layout[2, 1] = Label(scene, "analysis", fontsize=30)
     layout[2, 2] = analysis_menu
 
     axis_options = vcat([("None", nothing)], [(s, Symbol(s)) for s in propertynames(table.data)])
@@ -38,7 +38,7 @@ function gui!(scene, layout, df)
     N = length(mappings)
 
     for i in 1:N
-        layout[2+i, 1] = Label(scene, mappings[i], textsize=30)
+        layout[2+i, 1] = Label(scene, mappings[i], fontsize=30)
         layout[2+i, 2] = mapping_menus[i]
     end
 

--- a/src/facet.jl
+++ b/src/facet.jl
@@ -42,7 +42,7 @@ function facet_labels!(fig, aes, scale, dir)
     ax = first(nonemptyaxes(aes))
     color = ax.titlecolor
     font = ax.titlefont
-    textsize = ax.titlesize
+    fontsize = ax.titlesize
     visible = ax.titlevisible
 
     padding_index = dir == :row ? 1 : 3
@@ -51,10 +51,10 @@ function facet_labels!(fig, aes, scale, dir)
     end
 
     return map(plotvalues(scale), datavalues(scale)) do index, label
-        rotation = dir == :row ? -π/2 : 0.0 
+        rotation = dir == :row ? -π/2 : 0.0
         figpos = dir == :col ? fig[1, index, Top()] :
                  dir == :row ? fig[index, size(aes, 2), Right()] : fig[index..., Top()]
-        return Label(figpos, to_string(label); rotation, padding, color, font, textsize, visible)
+        return Label(figpos, to_string(label); rotation, padding, color, font, fontsize, visible)
     end
 end
 
@@ -98,8 +98,8 @@ function span_label!(fig, aes, var)
     rotation = var == :x ? 0.0 : π/2
     color = getattr(ax, :labelcolor)
     font = getattr(ax, :labelfont)
-    textsize = getattr(ax, :labelsize)
-    return Label(fig[pos..., Side()], label; rotation, padding, color, font, textsize)
+    fontsize = getattr(ax, :labelsize)
+    return Label(fig[pos..., Side()], label; rotation, padding, color, font, fontsize)
 end
 
 span_xlabel!(fig, aes) = span_label!(fig, aes, :x)
@@ -217,7 +217,7 @@ hide_ydecorations!(ax) = hideydecorations!(ax; grid=false, minorgrid=false)
 function hideinnerdecorations!(aes::AbstractArray{AxisEntries};
                                hidexdecorations, hideydecorations, wrap)
     I, J = size(aes)
-        
+
     if hideydecorations
         for i in 1:I, j in 2:J
             hide_ydecorations!(aes[i,j])

--- a/test/facet.jl
+++ b/test/facet.jl
@@ -74,7 +74,7 @@ end
         @test label.padding[] == (0, 0, ax.titlegap[], 0)
         @test label.color[] == ax.titlecolor[]
         @test label.font[] == ax.titlefont[]
-        @test label.textsize[] == ax.titlesize[]
+        @test label.fontsize[] == ax.titlesize[]
         @test label.visible[] == ax.titlevisible[]
     end
 
@@ -88,7 +88,7 @@ end
         @test label.padding[] == (ax.titlegap[], 0, 0, 0)
         @test label.color[] == ax.titlecolor[]
         @test label.font[] == ax.titlefont[]
-        @test label.textsize[] == ax.titlesize[]
+        @test label.fontsize[] == ax.titlesize[]
         @test label.visible[] == ax.titlevisible[]
     end
 
@@ -111,7 +111,7 @@ end
         @test label.padding[] == (0, 0, ax.titlegap[], 0)
         @test label.color[] == ax.titlecolor[]
         @test label.font[] == ax.titlefont[]
-        @test label.textsize[] == ax.titlesize[]
+        @test label.fontsize[] == ax.titlesize[]
         @test label.visible[] == ax.titlevisible[]
     end
 end
@@ -127,7 +127,7 @@ end
     @test label.rotation[] == 0
     @test label.color[] == ax.xlabelcolor[]
     @test label.font[] == ax.xlabelfont[]
-    @test label.textsize[] == ax.xlabelsize[]
+    @test label.fontsize[] == ax.xlabelsize[]
     @test label.text[] == "xlabel"
     @test label in contents(fig[3, :, Bottom()])
 
@@ -135,7 +135,7 @@ end
     @test label.rotation[] ≈ π/2
     @test label.color[] == ax.ylabelcolor[]
     @test label.font[] == ax.ylabelfont[]
-    @test label.textsize[] == ax.ylabelsize[]
+    @test label.fontsize[] == ax.ylabelsize[]
     @test label.text[] == "ylabel"
     @test label in contents(fig[:, 1, Left()])
 end


### PR DESCRIPTION
Makie v0.19 was just released with this breaking change (https://github.com/MakieOrg/Makie.jl/blob/master/NEWS.md#v0190):

>Breaking The attribute textsize has been removed everywhere in favor of the attribute fontsize which had also been in use. To migrate, search and replace all uses of textsize to fontsize https://github.com/MakieOrg/Makie.jl/pull/2387.

This PR makes AoG compatible with Make v0.19, and stops supporting previous versions of Makie.