### PR TITLE
documentation: tutorial, penguins example

### DIFF
--- a/docs/src/generated/penguins.jl
+++ b/docs/src/generated/penguins.jl
@@ -43,8 +43,8 @@ draw(penguin_frequency; axis=(; width = 225, height = 225))
 # inspect it in the file explorer.
 #
 # ```julia
-# fg = draw(penguin_frequency; axis)
-# save("figure.png", fg, px_per_unit = 3) # save high-resolution png
+# fg = draw(penguin_frequency; axis=(; width = 225, height = 225))
+# save("figure.svg", fg)
 # ```
 #
 # ### Styling by categorical variables
@@ -52,14 +52,14 @@ draw(penguin_frequency; axis=(; width = 225, height = 225))
 # Next, let us see whether the distribution is the same across islands.
 
 plt = penguin_frequency * mapping(color = :island)
-draw(plt; axis)
+draw(plt; axis=(; width = 225, height = 225))
 
 # Oops! The bars are in the same spot and are hiding each other. We need to specify
 # how we want to fix this. Bars can either `dodge` each other, or be `stack`ed on top
 # of each other.
 
 plt = penguin_frequency * mapping(color = :island, dodge = :island)
-draw(plt; axis)
+draw(plt; axis=(; width = 225, height = 225))
 
 # This is our first finding. `Adelie` is the only species of penguins that can be
 # found on all three islands. To be able to see both which species is more numerous
@@ -67,15 +67,16 @@ draw(plt; axis)
 # we could have used `stack`.
 
 plt = penguin_frequency * mapping(color = :island, stack = :island)
-draw(plt; axis)
+draw(plt; axis=(; width = 225, height = 225))
 
 # ## Correlating two variables
 #
 # Now that we have understood the distribution of these three penguin species, we can
 # start analyzing their features.
 
+ax = (; width = 225, height = 225)
 penguin_bill = data(penguins) * mapping(:bill_length_mm, :bill_depth_mm)
-draw(penguin_bill; axis)
+draw(penguin_bill; axis=ax)
 
 # We would actually prefer to visualize these measures in centimeters, and to have
 # cleaner axes labels. As we want this setting to be preserved in all of our `bill`
@@ -86,7 +87,7 @@ penguin_bill = data(penguins) * mapping(
     :bill_length_mm => (t -> t / 10) => "bill length (cm)",
     :bill_depth_mm => (t -> t / 10) => "bill depth (cm)",
 )
-draw(penguin_bill; axis)
+draw(penguin_bill; axis=ax)
 
 # Much better! Note the parentheses around the function `t -> t / 10`. They are
 # necessary to specify that the function maps `t` to `t / 10`, and not to
@@ -96,32 +97,32 @@ draw(penguin_bill; axis)
 # is odd. Maybe dividing the data by species will help.
 
 plt = penguin_bill * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # Ha! Within each species, penguins with a longer bill also have a deeper bill.
 # We can confirm that with a linear regression
 
 plt = penguin_bill * linear() * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # This unfortunately no longer shows our data!
 # We can use `+` to plot both things on top of each other:
 
 plt = penguin_bill * linear() * mapping(color = :species) + penguin_bill * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # Note that the above expression seems a bit redundant, as we wrote the same thing twice.
 # We can "factor it out" as follows
 
 plt = penguin_bill * (linear() + mapping()) * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # where `mapping()` is a neutral multiplicative element.
 # Of course, the above could be refactored as
 
 layers = linear() + mapping()
 plt = penguin_bill * layers * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # We could actually take advantage of the spare `mapping()` and use it to pass some
 # extra info to the scatter, while still using all the species members to compute
@@ -129,14 +130,14 @@ draw(plt; axis)
 
 layers = linear() + mapping(marker = :sex)
 plt = penguin_bill * layers * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # This plot is getting a little bit crowded. We could instead show female and
 # male penguins in separate subplots.
 
 layers = linear() + mapping(col = :sex)
 plt = penguin_bill * layers * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # See how both plots show the same fit, because the `sex` mapping is not applied
 # to `linear()`. The following on the other hand produces a separate fit for
@@ -144,7 +145,7 @@ draw(plt; axis)
 
 layers = linear() + mapping()
 plt = penguin_bill * layers * mapping(color = :species, col = :sex)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # ## Smooth density plots
 #
@@ -153,13 +154,13 @@ draw(plt; axis)
 
 using AlgebraOfGraphics: density
 plt = penguin_bill * density(npoints=50) * mapping(col = :species)
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # The default colormap is multi-hue, but it is possible to pass single-hue colormaps as well.
 # The color range is inferred from the data by default, but it can also be passed manually.
 
 plt *= visual(colormap = :grayC, colorrange = (0, 6))
-draw(plt; axis)
+draw(plt; axis=ax)
 
 # A `Heatmap` (the default visualization for a 2D density) is a bit unfortunate if
 # we want to mark species by color. In that case, one can use `visual` to change
@@ -170,20 +171,20 @@ draw(plt; axis)
 axis = (type = Axis3, width = 300, height = 300)
 layer = density() * visual(Wireframe, linewidth=0.05)
 plt = penguin_bill * layer * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # Of course, a more traditional approach would be to use a `Contour` plot instead:
 
 axis = (width = 225, height = 225)
 layer = density() * visual(Contour)
 plt = penguin_bill * layer * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # The data and the linear fit can also be added back to the plot:
 
 layers = density() * visual(Contour) + linear() + mapping()
 plt = penguin_bill * layers * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # In the case of many layers (contour, density and scatter) it is important to think
 # about balance. In the above plot, the markers are quite heavy and can obscure the linear
@@ -192,7 +193,7 @@ draw(plt; axis)
 
 layers = density() * visual(Contour) + linear() + visual(alpha = 0.5)
 plt = penguin_bill * layers * mapping(color = :species)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # ## Correlating three variables
 #
@@ -206,7 +207,7 @@ draw(plt; axis)
 body_mass = :body_mass_g => (t -> t / 1000) => "body mass (kg)"
 layers = linear() * mapping(group = :species) + mapping(color = body_mass, marker = :species)
 plt = penguin_bill * layers
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # Naturally, within each species, heavier penguins have bigger bills, but perhaps
 # counter-intuitively the species with the shallowest bills features the heaviest penguins.
@@ -214,12 +215,12 @@ draw(plt; axis)
 
 axis = (type = Axis3, width = 300, height = 300)
 plt = penguin_bill * mapping(body_mass, color = :species)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 #
 
 plt = penguin_bill * mapping(body_mass, color = :species, layout = :sex)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # Note that static 3D plot can be misleading, as they only show one projection
 # of 3D data. They are mostly useful when shown interactively.
@@ -270,7 +271,7 @@ plt = data(penguins) *
     expectation() *
     mapping(:species, accuracy) *
     mapping(col = dataset)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # That is a bit hard to read, as all values are very close to `1`.
 # Let us visualize the error rate instead.
@@ -280,7 +281,7 @@ plt = data(penguins) *
     expectation() *
     mapping(:species, error_rate) *
     mapping(col = dataset)
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # So, mostly our classifier is doing quite well, but there are some mistakes,
 # especially among `Chinstrap` penguins. Using *at the same time* the `species` and
@@ -290,7 +291,7 @@ draw(plt; axis)
 prediction = :predicted_species => "predicted species"
 datalayer = mapping(color = prediction, row = :species, col = dataset)
 plt = penguin_bill * datalayer
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # Um, some of the penguins are indeed being misclassified... Let us try to understand why
 # by adding an extra layer, which describes the density of the distributions of the three
@@ -299,7 +300,7 @@ draw(plt; axis)
 pdflayer = density() * visual(Contour, colormap=Reverse(:grays)) * mapping(group = :species)
 layers = pdflayer + datalayer
 plt = penguin_bill * layers
-draw(plt; axis)
+draw(plt; axis=axis)
 
 # We can conclude that the classifier is doing a reasonable job:
 # it is mostly making mistakes on outlier penguins.

--- a/docs/src/generated/penguins.jl
+++ b/docs/src/generated/penguins.jl
@@ -31,10 +31,9 @@ first(penguins, 6)
 using AlgebraOfGraphics, CairoMakie
 set_aog_theme!()
 
-axis = (width = 225, height = 225)
 penguin_frequency = data(penguins) * frequency() * mapping(:species)
 
-draw(penguin_frequency; axis)
+draw(penguin_frequency; axis=(; width = 225, height = 225))
 
 # ### Small intermezzo: saving the plot
 #


### PR DESCRIPTION
I just started learning about `AlgebraOfGraphics`, in the hope of switching over from `ggplot2` in `R`. I love it! I could use more help from the documentation. These [tutorials](https://tutorials.pumas.ai/html/PlottingInJulia/) have helped a lot for things I could not find here.
This PR is to fix 2 "errors" I ran across as a beginner, when learning to use AoG.

Here is a small example to reproduce the first error:

```julia
using AlgebraOfGraphics, CairoMakie
set_aog_theme!()
df1 = (x=[1,2,3,1,2,3], y=[4,3,1,5,3,2])
plt = data(df1) * mapping(:x,:y)

# replicating the tutorial example works:
axis = (width = 225, height = 225)
draw(plt; axis)

# but this fails, if I rename the variable 'axis'
# which was counterintuitive (at least for me not being familiar with Makie / AoG)
ax = (width = 225, height = 225)
draw(plt; ax)
# ERROR: MethodError: no method matching draw(::Layer; ax=(width = 225, height = 225)) ...
```
The suggested change makes it more explicit that `axis` is a keyword option, and helps to learn how to tweak figures.

The second "error" is that the png figure created with the `save(...)` example contains a tiny part of the plot only (top left corner). The suggested change doesn't have this issue, but uses svg instead. I don't know how to fix the issue with png, sorry (still learning!).

```julia
fg = draw(plt; axis=(; width = 225, height = 225))
save("figure.png", fg, px_per_unit = 3) # to reproduce the problematic (too small) png file
save("figure.svg", fg) # the svg file looks good.
```
