### PR TITLE
Use `alpha` for grouping

### DIFF
--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -58,6 +58,8 @@ function compute_legend(grid::Matrix{AxisEntries})
 
     plottypes, attributes = plottypes_attributes(entries(grid))
 
+    push!(attributes[1], :alpha)
+
     labels = Vector{AbstractString}[]
     elements_list = Vector{Vector{LegendElement}}[]
 
@@ -70,7 +72,7 @@ function compute_legend(grid::Matrix{AxisEntries})
                 shared_attrs = attrs ∩ label_attrs
                 isempty(shared_attrs) && continue
                 options = [attr => plotvalues(scales[attr])[idx] for attr in shared_attrs]
-                append!(elements, legend_elements(P; options...))
+                append!(elements, _legend_elements(P; options...))
             end
             return elements
         end

--- a/src/guides/legendelements.jl
+++ b/src/guides/legendelements.jl
@@ -1,5 +1,12 @@
 from_default_theme(attr) = Makie.current_default_theme()[attr]
 
+function _legend_elements(T; color=:black, alpha=automatic, kwargs...)
+	if alpha != automatic
+		color = (color, alpha)
+	end
+	legend_elements(T; color, kwargs...)
+end
+
 function legend_elements(::Type{Scatter};
                          marker=from_default_theme(:marker),
                          markerpoints=[Point2f(0.5, 0.5)],


### PR DESCRIPTION
#### Example 1: `BarPlot`

![image](https://user-images.githubusercontent.com/6280307/229142885-b2aa42f1-2d25-4c62-9820-3db68e0ce943.png)

```julia
bar_df = DataFrame(
	x = ["a", "a", "a", "b", "b"],
	y = [1, 1, 1, 1, 1],
	grp2 = "h" .* string.([1, 2, 1, 2, 1]),
	grp = "g" .* string.(1:5)
)

data(bar_df) * mapping(:x, :y, stack=:grp, color=:x, alpha=:grp2) * visual(BarPlot) |> draw
```

#### Example 2: `Scatter`

![image](https://user-images.githubusercontent.com/6280307/229143193-58e004be-99de-461b-82ea-d29cfe80c817.png)

```julia
n = 300
df = DataFrame(
	x = rand(n), 
	y = rand(n), 
	grp = rand(["a", "b", "c"], n),
	grp2 = rand(["x", "y", "z"], n),
	grp3 = rand(["l", "m", "n"], n)
)

data(df) * mapping(:x, :y, alpha = :grp, color=:grp2, layout=:grp3) * visual(Scatter) |> draw
```

#### Example 3: `Lines`

![image](https://user-images.githubusercontent.com/6280307/229144213-23ef359d-438c-4c39-9dbd-7d272d3bdfe4.png)

```julia
lines_df = let
	T = 100
	t = Int[]
	x = Float64[]
	grp1 = String[]
	grp2 = String[]
	grp3 = String[]

	grps = ["a", "b", "c"]
	
	for i ∈ 1:length(grps)
		for j ∈ 1:length(grps)
			for k ∈ 1:length(grps)
				append!(t, 1:T)
				append!(x, cumsum(randn(T)))
				append!(grp1, fill("1" * grps[i], T))
				append!(grp2, fill("2" * grps[j], T))
				append!(grp3, fill("3" * grps[k], T))
			end
		end
	end

	DataFrame(; t, x, grp1, grp2, grp3)
end

data(lines_df) * mapping(:t, :x, alpha = :grp1, color=:grp2, layout=:grp3) * visual(Lines) |> draw
```