### PR TITLE
Show styles from mapping in legends from `ScatterLines`, `VLines`, `HLines` and `ABLines`

### DIFF
--- a/src/guides/legendelements.jl
+++ b/src/guides/legendelements.jl
@@ -13,6 +13,15 @@ function legend_elements(::Union{Type{Lines}, Type{VLines}, Type{ABLines}};
     return [LineElement(; linecolor=color, kwargs...)]
 end
 
+function legend_elements(::Type{ScatterLines};
+                         marker=from_default_theme(:marker),
+                         markerpoints=[Point2f(0.5, 0.5)],
+                         color=from_default_theme(:markercolor),
+                         kwargs...)
+
+    return [MarkerElement(; marker, markerpoints, markercolor=color, kwargs...), LineElement(; linecolor=color, kwargs...)]
+end
+
 function legend_elements(::Type{Contour};
                          color=from_default_theme(:linecolor), kwargs...)
     return [LineElement(; linecolor=color, kwargs...)]

--- a/src/guides/legendelements.jl
+++ b/src/guides/legendelements.jl
@@ -8,7 +8,7 @@ function legend_elements(::Type{Scatter};
     return [MarkerElement(; marker, markerpoints, markercolor=color, kwargs...)]
 end
 
-function legend_elements(::Type{Lines};
+function legend_elements(::Union{Type{Lines}, Type{VLines}, Type{ABLines}};
                          color=from_default_theme(:linecolor), kwargs...)
     return [LineElement(; linecolor=color, kwargs...)]
 end

--- a/src/guides/legendelements.jl
+++ b/src/guides/legendelements.jl
@@ -8,7 +8,7 @@ function legend_elements(::Type{Scatter};
     return [MarkerElement(; marker, markerpoints, markercolor=color, kwargs...)]
 end
 
-function legend_elements(::Union{Type{Lines}, Type{VLines}, Type{ABLines}};
+function legend_elements(::Union{Type{Lines}, Type{VLines}, Type{HLines}, Type{ABLines}};
                          color=from_default_theme(:linecolor), kwargs...)
     return [LineElement(; linecolor=color, kwargs...)]
 end


### PR DESCRIPTION
Hello! I recently tried to generate a plot with `ScatterLines` specifying `mapping(...; marker=:var, linestyle=:var)`, but the resulting legend didn't show the styling appropriately. I noticed that this was pointed out on #435, along with a similar issue for `VLines`, so I followed @skleinbo's recommendation and modified `src/guides/legendelements.jl` the following way:

- Changed `legend_elements(::Type{Lines}; ...)` to `legend_elements(::Union{Type{Lines}, Type{VLines}, Type{HLines}, Type{ABLines}}; ...)` so that legends from `VLines`, `HLines` and `ABLines` also show the styling.
- Created `legend_elements(::Type{ScatterLines}; ...)` to support `ScatterLines` as well.

Intended to close #435 

