### PR TITLE
fix #472 as long Dictioanry.jl isn't fixed

### DIFF
--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -81,7 +81,7 @@ ProcessedLayer(layer::Layer) = process(layer)
 unnest(vs::AbstractArray, indices) = map(k -> [el[k] for el in vs], indices)
 
 unnest_arrays(vs) = unnest(vs, keys(first(vs)))
-unnest_dictionaries(vs) = unnest(vs, Indices(keys(first(vs))))
+unnest_dictionaries(vs) = Dictionary(unnest(vs, collect(keys(first(vs)))))
 
 slice(v, c) = map(el -> getnewindex(el, c), v)
 
@@ -198,7 +198,7 @@ function rescale(p::ProcessedLayer, categoricalscales::MixedArguments)
     return ProcessedLayer(p; primary, positional, attributes)
 end
 
-# Determine whether entries from a `ProcessedLayer` should be merged 
+# Determine whether entries from a `ProcessedLayer` should be merged
 function mergeable(processedlayer::ProcessedLayer)
     plottype, primary = processedlayer.plottype, processedlayer.primary
     # merge violins for correct renormalization
@@ -300,6 +300,6 @@ function compute_attributes(pl::ProcessedLayer,
     colorscale = get(continuousscales, :color, nothing)
     !isnothing(colorscale) && set!(attrs, :colorrange, colorscale.extrema)
 
-    # remove unnecessary information 
+    # remove unnecessary information
     return filterkeys(!in((:col, :row, :layout, :alpha)), attrs)
 end

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -81,8 +81,9 @@ ProcessedLayer(layer::Layer) = process(layer)
 unnest(vs::AbstractArray, indices) = map(k -> [el[k] for el in vs], indices)
 
 unnest_arrays(vs) = unnest(vs, keys(first(vs)))
-unnest_dictionaries(vs) = Dictionary(unnest(vs, collect(keys(first(vs)))))
-
+function unnest_dictionaries(vs)
+    return Dictionary(Dict((k => [el[k] for el in vs] for k in collect(keys(first(vs))))))
+end
 slice(v, c) = map(el -> getnewindex(el, c), v)
 
 function slice(processedlayer::ProcessedLayer, c)


### PR DESCRIPTION
Since https://github.com/andyferris/Dictionaries.jl/pull/127 has turned into a yak shave about Julia internals, I propose this work around in the meantime.
In the long run, I propose removing `Dictionaries.jl`, since we basically only use it instead of `Dict` for `map(f, ::Dict)`.