### PR TITLE
Fix a typo leading to `paginate(plt; row, col)` failures

### DIFF
--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -75,7 +75,7 @@ function paginate_layer(layer::ProcessedLayer; layout=nothing, row=nothing, col=
         paginate_layer(layer, row_data => row, col_data => col)
     elseif valid(row_data, row)
         paginate_layer(layer, row_data => row)
-    elseif valid(col, col)
+    elseif valid(col_data, col)
         paginate_layer(layer, col_data => col)
     else
         [layer]


### PR DESCRIPTION
~~I have a plot with many facets that I am not able to `paginate` using the `col` and `row` arguments.~~
`paginate(plt; row, col)` called on a plot that has no `row`/`col` inside `mapping` throws an error.
Fixing this typo prevents the error.