### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AlgebraOfGraphics
 
-[![CI](https://github.com/MakieOrg/AlgebraOfGraphics.jl/workflows/CI/badge.svg?branch=master)](https://github.com/MakieOrg/AlgebraOfGraphics.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![CI](https://github.com/MakieOrg/AlgebraOfGraphics.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/MakieOrg/AlgebraOfGraphics.jl/actions/workflows/ci.yml)
 [![codecov.io](http://codecov.io/github/MakieOrg/AlgebraOfGraphics.jl/coverage.svg?branch=master)](http://codecov.io/github/MakieOrg/AlgebraOfGraphics.jl?branch=master)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://aog.makie.org/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://aog.makie.org/dev)


### PR DESCRIPTION
The old path kept showing a failing status even though tests are passing.