### PR TITLE
Add ability to return `ProcessedLayers` from transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added ability to return `ProcessedLayers` from transformations, thereby enabling multi-layer transformations, such as scatter plus errorbars [#549](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/549).
+
 ## v0.8.6 - 2024-09-02
 
 - Added `bar_labels` to `BarPlot`'s aesthetic mapping [#544](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/544).

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -149,6 +149,24 @@ function ProcessedLayer(processedlayer::ProcessedLayer; kwargs...)
     return ProcessedLayer(; merge(nt, values(kwargs))...)
 end
 
+"""
+    ProcessedLayer(l::Layer)
+
+Process a `Layer` and return the resulting `ProcessedLayer`.
+
+Note that this method should not be used anymore as processing a `Layer`
+can now potentially return multiple `ProcessedLayer` objects.
+Therefore, you should use the plural form `ProcessedLayers(layer)`.
+"""
+function ProcessedLayer(l::Layer)
+    processedlayers = ProcessedLayers(l)
+    n = length(processedlayers.layers)
+    if n != 1
+        error("Received $n `ProcessedLayer`s when calling `ProcessedLayer(layer)`. If you have a layer whose processing returns zero or multiple `ProcessedLayer`s, use `ProcessedLayers(layer)` instead.")
+    end
+    return processedlayers.layers[]
+end
+
 unnest(vs::AbstractArray, indices) = map(k -> [el[k] for el in vs], indices)
 
 unnest_arrays(vs) = unnest(vs, keys(first(vs)))

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -149,18 +149,6 @@ function ProcessedLayer(processedlayer::ProcessedLayer; kwargs...)
     return ProcessedLayer(; merge(nt, values(kwargs))...)
 end
 
-"""
-    ProcessedLayers(layer::Layer)
-
-Output of processing a `layer`. Each `ProcessedLayer` encodes
-- plot type,
-- grouping arguments,
-- positional and named arguments for the plot,
-- labeling information,
-- visual attributes.
-"""
-ProcessedLayers(layer::Layer) = process(layer)
-
 unnest(vs::AbstractArray, indices) = map(k -> [el[k] for el in vs], indices)
 
 unnest_arrays(vs) = unnest(vs, keys(first(vs)))

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -150,16 +150,16 @@ function ProcessedLayer(processedlayer::ProcessedLayer; kwargs...)
 end
 
 """
-    ProcessedLayer(layer::Layer)
+    ProcessedLayers(layer::Layer)
 
-Output of processing a `layer`. A `ProcessedLayer` encodes
+Output of processing a `layer`. Each `ProcessedLayer` encodes
 - plot type,
 - grouping arguments,
 - positional and named arguments for the plot,
 - labeling information,
 - visual attributes.
 """
-ProcessedLayer(layer::Layer) = process(layer)
+ProcessedLayers(layer::Layer) = process(layer)
 
 unnest(vs::AbstractArray, indices) = map(k -> [el[k] for el in vs], indices)
 

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -38,7 +38,8 @@ end
 
 function ProcessedLayers(a::AbstractAlgebraic)
     layers::Layers = a
-    return ProcessedLayers(map(process, layers))
+    processedlayers_array = map(process, layers)
+    return ProcessedLayers(reduce(vcat, [processedlayer.layers for processedlayer in processedlayers_array]))
 end
 
 """

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -41,6 +41,18 @@ function ProcessedLayers(a::AbstractAlgebraic)
     return ProcessedLayers(map(process, layers))
 end
 
+"""
+    ProcessedLayers(layer::Layer)
+
+Output of processing a `layer`. Each `ProcessedLayer` encodes
+- plot type,
+- grouping arguments,
+- positional and named arguments for the plot,
+- labeling information,
+- visual attributes.
+"""
+ProcessedLayers(layer::Layer) = process(layer)
+
 ProcessedLayers(p::ProcessedLayer) = ProcessedLayers([p])
 ProcessedLayers(p::ProcessedLayers) = p
 

--- a/src/algebra/processing.jl
+++ b/src/algebra/processing.jl
@@ -162,10 +162,12 @@ function process(layer::Layer)
     processedlayer = process_mappings(layer)
     grouped_entry = layer.data === Pregrouped() ? processedlayer : group(processedlayer)
     primary = map(vs -> map(getuniquevalue, vs), grouped_entry.primary)
-    transformed_processlayer = layer.transformation(ProcessedLayer(grouped_entry; primary))
-    attributes = merge(mandatory_attributes(transformed_processlayer.plottype), transformed_processlayer.attributes)
-    possibly_without_visual = ProcessedLayer(transformed_processlayer; attributes)
-    return set_missing_visual(possibly_without_visual)
+    transformed_processlayers = ProcessedLayers(layer.transformation(ProcessedLayer(grouped_entry; primary)))
+    return ProcessedLayers(map(transformed_processlayers.layers) do transformed_processlayer
+        attributes = merge(mandatory_attributes(transformed_processlayer.plottype), transformed_processlayer.attributes)
+        possibly_without_visual = ProcessedLayer(transformed_processlayer; attributes)
+        return set_missing_visual(possibly_without_visual)
+    end)
 end
 
 function set_missing_visual(p::ProcessedLayer)

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -77,7 +77,7 @@ end
     df.c[1:3] .= ["a", "b", "c"] # ensure all three values exist
     d = mapping(:x => exp, [:y, :z], color=:c, marker=dims(1) => t -> ["1", "2"][t], markersize=:w)
     layer = data(df) * d * visual(Scatter)
-    processedlayer = AlgebraOfGraphics.ProcessedLayer(layer)
+    processedlayer = AlgebraOfGraphics.ProcessedLayers(layer).layers[]
     processedlayers = map(CartesianIndices(AlgebraOfGraphics.shape(processedlayer))) do c
         primary, positional, named = map((processedlayer.primary, processedlayer.positional, processedlayer.named)) do tup
             return map(v -> v[c], tup)

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -77,7 +77,7 @@ end
     df.c[1:3] .= ["a", "b", "c"] # ensure all three values exist
     d = mapping(:x => exp, [:y, :z], color=:c, marker=dims(1) => t -> ["1", "2"][t], markersize=:w)
     layer = data(df) * d * visual(Scatter)
-    processedlayer = AlgebraOfGraphics.ProcessedLayers(layer).layers[]
+    processedlayer = AlgebraOfGraphics.ProcessedLayer(layer)
     processedlayers = map(CartesianIndices(AlgebraOfGraphics.shape(processedlayer))) do c
         primary, positional, named = map((processedlayer.primary, processedlayer.positional, processedlayer.named)) do tup
             return map(v -> v[c], tup)


### PR DESCRIPTION
This could be useful, for example, to implement transformations that have multiple layers like mean + std, or something like `gghighlight` where some layers are grayed out and others are left as they are.