### PR TITLE
Add `highlight` transformation

### DIFF
--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -33,7 +33,7 @@ export hideinnerdecorations!, deleteemptyaxes!
 export Layer, Layers, ProcessedLayer, ProcessedLayers
 export Entry, AxisEntries
 export renamer, sorter, nonnumeric, verbatim, presorted
-export density, histogram, linear, smooth, expectation, frequency, contours, filled_contours
+export density, histogram, linear, smooth, expectation, frequency, contours, filled_contours, highlight
 export visual, data, geodata, dims, mapping
 export datetimeticks
 export draw, draw!
@@ -69,6 +69,7 @@ include("transformations/frequency.jl")
 include("transformations/expectation.jl")
 include("transformations/contours.jl")
 include("transformations/filled_contours.jl")
+include("transformations/highlight.jl")
 include("guides/guides.jl")
 include("guides/legend.jl")
 include("guides/colorbar.jl")

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -92,6 +92,9 @@ end
 
 categorical_scales_mergeable(c1, c2) = false # there can be continuous scales in the mix, like markersize
 
+is_empty_categorical_scale(s::CategoricalScale) = isempty(datavalues(s))
+is_empty_categorical_scale(s::ContinuousScale) = false
+
 function compute_legend(grid::Matrix{AxisEntries}; order::Union{Nothing,AbstractVector})
     # gather valid named scales
     scales_categorical = legendable_scales(Val(:categorical), first(grid).categoricalscales)
@@ -100,7 +103,7 @@ function compute_legend(grid::Matrix{AxisEntries}; order::Union{Nothing,Abstract
     scales = Iterators.flatten((pairs(scales_categorical), pairs(scales_continuous)))
 
     # if no legendable scale is present, return nothing
-    isempty(scales) && return nothing
+    isempty(scales) || all(x -> all(is_empty_categorical_scale, last(x)), scales) && return nothing
 
     scales_by_symbol = Dictionary{Symbol,ScaleWithMeta}()
 

--- a/src/transformations/highlight.jl
+++ b/src/transformations/highlight.jl
@@ -1,0 +1,51 @@
+struct Highlight{F<:Function}
+    target::Vector{Union{Int,Symbol}}
+    predicate::F
+    repeat_facets::Bool
+end
+
+function Highlight(
+    target::Vector,
+    predicate;
+    repeat_facets = false
+)
+    return Highlight(
+        convert(Vector{Union{Int,Symbol}}, target),
+        predicate,
+        repeat_facets
+    )
+end
+
+function (highlight::Highlight)(p::ProcessedLayer)
+    primary = AlgebraOfGraphics.dictionary([(key == :color ? :group : key, value) for (key, value) in pairs(p.primary)
+        # should the data be repeated across all facets or not? maybe needs to be an option
+        if !(highlight.repeat_facets && key in (:layout, :row, :col))
+    ])
+    
+    grayed_out = ProcessedLayer(p; primary, attributes = merge(p.attributes, AlgebraOfGraphics.dictionary([:color => :gray80])))
+
+    function apply_predicate(target::Vector, predicate::Function, positional, named, scalar_primaries)
+        b = predicate([resolve_target(t, positional, named, scalar_primaries) for t in target]...)
+        b isa Bool || error("Highlighting predicate returned non-boolean value $b")
+        return b
+    end
+    
+    resolve_target(target::Int, positional, named, scalar_primaries) = positional[target]
+    resolve_target(target::Symbol, positional, named, scalar_primaries) = haskey(scalar_primaries, target) ? scalar_primaries[target] : named[target]
+
+
+    i::Int = 0
+    colored = AlgebraOfGraphics.filtermap(p) do positional, named
+        i += 1
+        scalar_primaries = map(val -> val[i], p.primary)
+        if apply_predicate(highlight.target, highlight.predicate, positional, named, scalar_primaries)
+            return positional, named
+        else
+            return nothing
+        end
+    end
+
+    return ProcessedLayers([grayed_out, colored])
+end
+
+highlight(pair::Pair; kwargs...) = AlgebraOfGraphics.transformation(Highlight(vcat(pair[1]), pair[2]; kwargs...))


### PR DESCRIPTION
The `highlight` transformation has a similar effect as the [gghighlight](https://cran.r-project.org/web/packages/gghighlight/vignettes/gghighlight.html) extension from the ggplot ecosystem.

You can pass predicates which are then evaluated on the subgroups created by the given grouping variables in `mapping`.
For example, this plot highlights all series with standard deviation of positional arg 2 (the y data) over some threshold:

```julia
using Statistics
using Random

Random.seed!(5)

nx = 100
ngroup = 8
df = (;
    x = repeat(1:nx, ngroup),
    y = reduce(vcat, [randn(nx) .* rand(range(0.01, 0.3, length = 20)) .+ i for i in 1:ngroup]),
    group = repeat(Char.(Int('A') .+ (0:ngroup-1)), inner = nx)
)
fg = data(df) *
    mapping(:x, :y, color = :group, layout = :group => x -> x > 'D' ? "Upper" : "Lower") *
    visual(Lines) *
    highlight(2 => y -> std(y) > 0.2) |> draw
```

<img width="488" alt="image" src="https://github.com/user-attachments/assets/a18ca6e4-fda5-446d-bec6-f1ce601902d3">

You can also repeat the data split over facets in each facet. Whatever transformation has been done previously on that data in the facetted context will remain (so for example the histogram binning when using `histogram()`):

```julia
data((; x = randn(900) .+ repeat(0:3:6, inner = 300), group = repeat('A':'C', inner = 300))) *
    mapping(:x, color = :group, col = :group) *
    histogram(bins = 30) *
    highlight(:color => Returns(true), repeat_facets = true) |> draw
```

<img width="501" alt="image" src="https://github.com/user-attachments/assets/6a0df4b5-63a9-418d-a01c-2918e33ec725">
