### PR TITLE
Axis attributes when drawing pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.9.1 - 2025-01-31
+
+- Fixed passing `axis` keyword to `draw(::Pagination, ...)` [#595](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/595).
+
 ## v0.9.0 - 2025-01-30
 
 - **Breaking**: `paginate` now splits facet plots into pages _after_ fitting scales and not _before_ [#593](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/593). This means that, e.g., categorical color mappings are consistent across pages where before each page could have a different mapping if some groups were not represented on a given page. This change also makes pagination work with the split X and Y scales feature enabled by version 0.8.14. `paginate`'s return type changes from `PaginatedLayers` to `Pagination` because no layers are stored in that type anymore. The interface to use `Pagination` with `draw` and other functions doesn't change compared to `PaginatedLayers`. `paginate` now also accepts an optional second positional argument which are the scales that are normally passed to `draw` when not paginating, but which must be available prior to pagination to fit all scales accordingly.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -157,7 +157,16 @@ function _draw(d::AbstractDrawable, scales::Scales;
     ae = compute_axes_grid(d, scales; axis)
     _draw(ae; figure, facet, legend, colorbar)
 end
-function _draw(ae::Matrix{AxisSpecEntries}; figure = (;), facet = (;), legend = (;), colorbar = (;))
+
+function _draw(ae::Matrix{AxisSpecEntries}; axis = Dictionary{Symbol,Any}(), figure = Dictionary{Symbol,Any}(), facet = Dictionary{Symbol,Any}(), legend = Dictionary{Symbol,Any}(), colorbar = Dictionary{Symbol,Any}())
+
+    if !isempty(axis)
+        # merge in axis attributes here because pagination runs `compute_axes_grid`
+        # which in the normal `draw` pipeline consumes `axis`
+        ae = map(ae) do ase
+            Accessors.@set ase.axis.attributes = merge(ase.axis.attributes, axis)
+        end
+    end
 
     fs, remaining_figure_kw = figure_settings(; pairs(figure)...)
 

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -26,7 +26,14 @@ end
 Draw each element of `Pagination` `p` and return a `Vector{FigureGrid}`.
 Keywords `kws` are passed to the underlying `draw` calls.
 """
-draw(p::Pagination; kws...) = _draw.(p.each; kws...)
+function draw(p::Pagination; axis = (;), figure = (;), facet = (;), legend = (;), colorbar = (;))
+    axis = _kwdict(axis)
+    figure = _kwdict(figure)
+    facet = _kwdict(facet)
+    legend = _kwdict(legend)
+    colorbar = _kwdict(colorbar)
+    _draw.(p.each; axis, figure, facet, legend, colorbar)
+end
 
 """
     draw(p::Pagination, i::Int; kws...)
@@ -36,11 +43,16 @@ Keywords `kws` are passed to the underlying `draw` call.
 
 You can retrieve the number of elements using `length(p)`.
 """
-function draw(p::Pagination, i::Int; kws...)
+function draw(p::Pagination, i::Int; axis = (;), figure = (;), facet = (;), legend = (;), colorbar = (;))
     if i ∉ 1:length(p)
         throw(ArgumentError("Invalid index $i for Pagination with $(length(p)) entries."))
     end
-    _draw(p.each[i]; kws...)
+    axis = _kwdict(axis)
+    figure = _kwdict(figure)
+    facet = _kwdict(facet)
+    legend = _kwdict(legend)
+    colorbar = _kwdict(colorbar)
+    _draw(p.each[i]; axis, figure, facet, legend, colorbar)
 end
 
 function draw(p::Pagination, ::Scales, args...; kws...)

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -78,3 +78,15 @@ end
 
     @test_throws_message "Calling `draw` with a `Pagination` object and `scales` is invalid." draw(p, scl)
 end
+
+@testset "Axis attributes when drawing pagination" begin
+    spec = data((; x = 1:10, y = 11:20, group = repeat(["A", "B"]))) * mapping(:x, :y, layout = :group)
+    p = paginate(spec, layout = 1)
+    fgrid = draw(p, 1; axis = (; xlabelcolor = :tomato))
+    ax = only(fgrid.grid).axis
+    @test ax.xlabelcolor[] == Makie.to_color(:tomato)
+    
+    fgrids = draw(p; axis = (; xlabelcolor = :tomato))
+    ax = only(fgrids[1].grid).axis
+    @test ax.xlabelcolor[] == Makie.to_color(:tomato)
+end


### PR DESCRIPTION
Doing `p = paginate(...); draw(p; axis = (; xlabelcolor = :red))` wasn't working because `axis` is already consumed into `AxisSpecEntries` in the normal pipeline. This PR fixes that by merging `axis` into the existing specs.