### PR TITLE
do dark mode logo

### DIFF
--- a/docs/src/.vitepress/theme/style.css
+++ b/docs/src/.vitepress/theme/style.css
@@ -211,3 +211,7 @@
       user-select: none;
       margin: 0 0 8px;
   }
+  
+  .dark .VPHero .image-src {
+    content: url(/logo-dark.svg);
+  }

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,8 +47,12 @@ spec =
     (visual(Scatter, alpha = 0.3) + linear())
 
 draw(spec)
+save("demo_hero.png", current_figure()) # hide
 ```
 
+````@raw html
+<img src="./demo_hero.png" style="max-width: 640px; width: 100%; height: auto;">
+````
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,6 +48,7 @@ spec =
 
 draw(spec)
 save("demo_hero.png", current_figure()) # hide
+nothing # hide
 ```
 
 ````@raw html


### PR DESCRIPTION
- this adds some css to include the logo when we are in the dark mode. 
- limits the max-size of the `demo_hero` image, which currently is too big in big screens 😄 .

the logo at the top left should be fixed once https://github.com/LuxDL/DocumenterVitepress.jl/issues/208 is solved 😓 .