### PR TITLE
Draw to Makie.SpecApi spec

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -255,3 +255,43 @@ function Base.showerror(io::IO, pe::PaletteError)
         """
     print(io, msg)
 end
+
+function draw_to_spec(spec, scales = scales())
+    agrid = compute_axes_grid(spec, scales)
+
+    S = Makie.SpecApi
+
+    axisspecs = map(vec(agrid)) do ase
+        ax = ase.axis
+        axtype = ax.type === Axis ? S.Axis : ax.type === Axis3 ? S.Axis3 : error()
+
+        isempty(ase.entries) && return nothing
+
+        plots::Vector{Makie.PlotSpec} = map(ase.entries) do entry
+            Makie.PlotSpec(entry.plottype, entry.positional...; pairs(entry.named)...)
+        end
+
+        ax.position => axtype(; plots, pairs(ax.attributes)...)
+    end
+
+    axisspecs = [x for x in axisspecs if x !== nothing]
+
+    for axisspec in axisspecs[2:end]
+        axisspecs[1][2].then() do ax1
+            axisspec[2].then() do ax2
+                linkaxes!(ax1, ax2)
+            end
+            return
+        end
+    end
+
+    legend = compute_legend(agrid; order = nothing)
+    if legend !== nothing
+        gridsize = size(agrid)
+        legendpos = (:, gridsize[2] + 1)
+        legendspec = S.Legend(legend...)
+        axisspecs = [axisspecs; legendpos => legendspec]
+    end
+
+    return S.GridLayout(axisspecs)
+end

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -92,7 +92,7 @@ end
 
 categorical_scales_mergeable(c1, c2) = false # there can be continuous scales in the mix, like markersize
 
-function compute_legend(grid::Matrix{AxisEntries}; order::Union{Nothing,AbstractVector})
+function compute_legend(grid::Matrix{<:Union{AxisEntries,AxisSpecEntries}}; order::Union{Nothing,AbstractVector})
     # gather valid named scales
     scales_categorical = legendable_scales(Val(:categorical), first(grid).categoricalscales)
     scales_continuous = legendable_scales(Val(:continuous), first(grid).continuousscales)


### PR DESCRIPTION
Turning an AoG spec into a Makie spec allows to update an AoG plot interactively

https://github.com/user-attachments/assets/047c72eb-4620-44a0-b3e9-d0b6f9038c1c

This is so far only a very basic proof of concept. 