### PR TITLE
added informative error when legend is not a named tuple

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -79,7 +79,7 @@ function draw(d::AbstractDrawable, scales::Scales = scales();
     axis = _kwdict(axis)
     figure = _kwdict(figure)
     facet = _kwdict(facet)
-    legend = _kwdict(legend)
+    legend = (!isa(legend, NamedTuple)) ? throw(DomainError("legend provided is not a NamedTuple. If you specified a single name-value pair, add a hanging comma like so: (name = value, )")) : _kwdict(legend)
     colorbar = _kwdict(colorbar)
 
     return _draw(d, scales; axis, figure, facet, legend, colorbar)

--- a/test/legend.jl
+++ b/test/legend.jl
@@ -155,3 +155,10 @@ end
     @test Makie.to_value(els[3].alpha) == 0.5
     @test Makie.to_value(els[4].alpha) == 1.0
 end
+
+@testset "legend named tuple #PR #617" begin
+    dat = DataFrame(grp = ["A", "B", "C"], x = [1., 2., 3.], y = [1., 2., 3.])
+    plt = data(dat) * mapping(:x, :y, color = :grp) * visual(Scatter)
+    @test_throws DomainError draw(plt, legend = (position = :bottom))
+    @test isa(draw(plt, legend = (position = :bottom,)), AlgebraOfGraphics.FigureGrid)
+end


### PR DESCRIPTION
the `draw` function calls `_kwdict` on `legend` argument, which expects a `NamedTuple` or at least a `Tuple`. If only one name-value pair is provided such as `draw(..., legend = (position = :bottom))` the legend is of type `Symbol` and not a named tuple. The error thrown when this happens is uinformative, see #616. This PR provides a more helpful error with a suggestion and tells the use to add a hanging comma like here: `draw(..., legend = (position = :bottom, ))`

fixes #616 