### PR TITLE
catch errors in `_kwdict` and give nice error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added better error messages for the common case of failing to construct single element NamedTuples in calls like `draw(axis = (key = value))` [#630](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/630).
+
 ## v0.10.0 - 2025-03-30
 
 - **Breaking**: The `colorbar!` function now returns a `Vector{Colorbar}` with zero or more entries. Before it would return `Union{Nothing,Colorbar}`, but now it's possible to draw more than one colorbar if there are multiple colorscales [#628](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/628).

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -27,11 +27,11 @@ Draw each element of `Pagination` `p` and return a `Vector{FigureGrid}`.
 Keywords `kws` are passed to the underlying `draw` calls.
 """
 function draw(p::Pagination; axis = (;), figure = (;), facet = (;), legend = (;), colorbar = (;))
-    axis = _kwdict(axis)
-    figure = _kwdict(figure)
-    facet = _kwdict(facet)
-    legend = _kwdict(legend)
-    colorbar = _kwdict(colorbar)
+    axis = _kwdict(axis, :axis)
+    figure = _kwdict(figure, :figure)
+    facet = _kwdict(facet, :facet)
+    legend = _kwdict(legend, :legend)
+    colorbar = _kwdict(colorbar, :colorbar)
     _draw.(p.each; axis, figure, facet, legend, colorbar)
 end
 
@@ -47,11 +47,11 @@ function draw(p::Pagination, i::Int; axis = (;), figure = (;), facet = (;), lege
     if i ∉ 1:length(p)
         throw(ArgumentError("Invalid index $i for Pagination with $(length(p)) entries."))
     end
-    axis = _kwdict(axis)
-    figure = _kwdict(figure)
-    facet = _kwdict(facet)
-    legend = _kwdict(legend)
-    colorbar = _kwdict(colorbar)
+    axis = _kwdict(axis, :axis)
+    figure = _kwdict(figure, :figure)
+    facet = _kwdict(facet, :facet)
+    legend = _kwdict(legend, :legend)
+    colorbar = _kwdict(colorbar, :colorbar)
     _draw(p.each[i]; axis, figure, facet, legend, colorbar)
 end
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -61,7 +61,7 @@ The values attached to the keywords must be dict-like, with `Symbol`s as keys (s
 function scales(; kwargs...)
     dict = Dictionary{Symbol,Dictionary{Symbol,Any}}()
     for (kw, value) in pairs(kwargs)
-        insert!(dict, kw, _kwdict(value))
+        insert!(dict, kw, _kwdict(value, kw))
     end
     return Scales(dict)
 end

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -83,3 +83,8 @@ end
         Presorted("a", 0x0002),
     ]
 end
+
+@testset "_kwdict errors" begin
+    spec = mapping()
+    @test_throws_message "Can't convert value passed via the keyword `axis`" draw(spec, axis = (key = :value))
+end


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/AlgebraOfGraphics.jl/issues/616

The example from that issue now gives

```julia
julia> draw(..., legend = (position = :bottom))

ERROR: ArgumentError: Can't convert value passed via the keyword `legend` to a
`Dictionary{Symbol,Any}`. If you intended to pass a single-element `NamedTuple`,
check that you didn't write `legend = (key = value)` as this expression resolves to
just `value`. Use either `legend = (; key = value)` or `legend = (key = value,)`.
The invalid value that was passed was:

:bottom

The underlying error message was:

MethodError: no method matching keys(::Symbol)
The function `keys` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  keys(!Matched::Base.TermInfo)
   @ Base terminfo.jl:232
  keys(!Matched::Cmd)
   @ Base process.jl:716
  keys(!Matched::Pkg.Registry.RegistryInstance)
   @ Pkg ~/.julia/juliaup/julia-1.11.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Pkg/src/Registry/registry_instance.jl:449
  ...

Stacktrace:
 [1] _kwdict(prs::Symbol, keyword::Symbol)
   @ AlgebraOfGraphics ~/.julia/dev/AlgebraOfGraphics/src/draw.jl:43
 [2] draw(d::Layer, scales::AlgebraOfGraphics.Scales; axis::@NamedTuple{}, figure::@NamedTuple{}, facet::@NamedTuple{}, legend::Symbol, colorbar::@NamedTuple{}, palette::Nothing)
```

Previously it gave

```
MethodError: no method matching iterate(::Symbol)
The function `iterate` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  iterate(::Layers, Any...)
   @ AlgebraOfGraphics ~/.julia/packages/AlgebraOfGraphics/E0gIq/src/algebra/layers.jl:16
  iterate(::LaTeXStrings.LaTeXString, ::Int64)
   @ LaTeXStrings ~/.julia/packages/LaTeXStrings/6NrIG/src/LaTeXStrings.jl:108
  iterate(::LaTeXStrings.LaTeXString)
   @ LaTeXStrings ~/.julia/packages/LaTeXStrings/6NrIG/src/LaTeXStrings.jl:109
  ...


Stacktrace:
 [1] isempty(itr::Symbol)
   @ Base ./essentials.jl:1121
 [2] _kwdict(prs::Symbol)
   @ AlgebraOfGraphics ~/.julia/packages/AlgebraOfGraphics/E0gIq/src/draw.jl:33
 [3] draw(d::Layer, scales::AlgebraOfGraphics.Scales; axis::@NamedTuple{}, figure::@NamedTuple{size::Tuple{Int64, Int64}}, facet::@NamedTuple{}, legend::Symbol, colorbar::@NamedTuple{}, palette::Nothing)
   @ AlgebraOfGraphics ~/.julia/packages/AlgebraOfGraphics/E0gIq/src/draw.jl:82
 [4] top-level scope
   @ In[32]:3
```