### PR TITLE
`verbatim` without aesthetics

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -114,7 +114,6 @@ function aesthetic_mapping(::Type{BarPlot}, N::Int)
             :y => AesY,
             :x => AesX,
         ]),
-        :bar_labels => AesText,
     ])
 end
 
@@ -274,7 +273,6 @@ function aesthetic_mapping(::Type{Makie.Text}, ::Normal, ::Normal)
     dictionary([
         1 => AesX,
         2 => AesY,
-        :text => AesText,
         :color => AesColor,
     ])
 end

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -19,7 +19,6 @@ struct AesDodgeX <: Aesthetic end
 struct AesDodgeY <: Aesthetic end
 struct AesStack <: Aesthetic end
 struct AesLineStyle <: Aesthetic end
-struct AesText <: Aesthetic end
 # all these plot specific ones seem kind of unnecessary, but not sure what to do with them yet,
 # maybe aesthetics that completely avoid scales 
 struct AesViolinSide <: Aesthetic end

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -194,3 +194,25 @@ end
     @test pls[1].positional == [[1, 2, 3], [4, 5, 6]]
     @test pls[2].positional == [[11, 12, 13], [14, 15, 16]]
 end
+
+@testset "verbatim works without scales" begin
+    colors = RGBf.(range(0, 1, length = 10), 0.5, 0.5)
+    fontsizes = range(20, 40, length = 10)
+    aligns = tuple.(range(0, 1, length = 10), range(0, 1, length = 10))
+    layer = mapping(
+        1:10,
+        1:10,
+        text = "hi" => verbatim,
+        color = colors => verbatim,
+        fontsize = fontsizes => verbatim,
+        align = aligns => verbatim,
+    ) * visual(Makie.Text)
+
+    ag = AlgebraOfGraphics.compute_axes_grid(layer, scales())
+    e = only(ag[1].entries)
+    @test e.named[:fontsize] == fontsizes
+    @test e.named[:align] == aligns
+    @test e.named[:color] == colors
+
+    @test_nowarn draw(layer)
+end

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -215,4 +215,24 @@ end
     @test e.named[:color] == colors
 
     @test_nowarn draw(layer)
+
+    layer2 = mapping(
+        1:10,
+        1:10,
+        layout = repeat(["A", "B"], inner = 5),
+        text = "hi" => verbatim,
+        color = colors => verbatim,
+        fontsize = fontsizes => verbatim,
+        align = aligns => verbatim,
+    ) * visual(Makie.Text)
+    
+    ag = AlgebraOfGraphics.compute_axes_grid(layer2, scales())
+    e = only(ag[1].entries)
+    @test e.named[:fontsize] == fontsizes[1:5]
+    @test e.named[:align] == aligns[1:5]
+    @test e.named[:color] == colors[1:5]
+    e2 = only(ag[2].entries)
+    @test e2.named[:fontsize] == fontsizes[6:10]
+    @test e2.named[:align] == aligns[6:10]
+    @test e2.named[:color] == colors[6:10]
 end


### PR DESCRIPTION
So far, anything used in a `mapping` had to have a corresponding aesthetic mapping entry for the plot type used. All other attributes had to be passed in `visual`. But that meant that only scalar attributes could reliably be used via `visual`, as the data in `visual` does not participate in the grouping & slicing mechanism like the data in `mapping` does.

This PR changes the rules so that an attribute passed `verbatim` sidesteps the aesthetics entirely, so no aesthetic mapping needs to be defined for the plot type for that attribute, which makes it much easier to pass array attributes through to Makie.

## Before

```julia
mapping(
    1:10,
    1:10,
    layout = repeat(["A", "B"], inner = 5),
    text = string.('A':'J') => verbatim,
    color = RGBf.(range(0, 1, length = 10), 0.5, 0.5) => verbatim,
    fontsize = range(20, 40, length = 10) => verbatim,
    align = tuple.(range(0, 1, length = 10), range(0, 1, length = 10)) => verbatim,
) * visual(Makie.Text) |> draw

ERROR: ArgumentError: ProcessedLayer with plot type MakieCore.Text did not have :fontsize in its AestheticMapping. The mapping was {1 = AlgebraOfGraphics.AesX, 2 = AlgebraOfGraphics.AesY, :text = AlgebraOfGraphics.AesText, :color = AlgebraOfGraphics.AesColor}
```

## After

The attributes without aesthetics can be passed `verbatim` and are sliced correctly via `layout`.

```julia
mapping(
    1:10,
    1:10,
    layout = repeat(["A", "B"], inner = 5),
    text = string.('A':'J') => verbatim,
    color = RGBf.(range(0, 1, length = 10), 0.5, 0.5) => verbatim,
    fontsize = range(20, 40, length = 10) => verbatim,
    align = tuple.(range(0, 1, length = 10), range(0, 1, length = 10)) => verbatim,
) * visual(Makie.Text) |> draw
```

<img width="516" alt="image" src="https://github.com/user-attachments/assets/57fdaa4f-4a9f-49ad-93f3-b8c3b7769b3f" />
