### PR TITLE
Label metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- If available, column metadata with the key `"label"` will be used instead of the column name for determining a mapping's label [#660](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/660).
+
 ## v0.10.5 - 2025-05-14
 
 - Added a new `AesLineWidth` aesthetic for `Lines`, `ScatterLines`, `HLines` and `VLines` [#656](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/656).

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.10.5"
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -38,6 +39,7 @@ AlgebraOfGraphicsUnitfulExt = "Unitful"
 [compat]
 Accessors = "0.1"
 Colors = "0.12, 0.13"
+DataAPI = "1"
 Dictionaries = "0.3, 0.4"
 DynamicQuantities = "1"
 FileIO = "1.1"
@@ -63,6 +65,7 @@ julia = "1.6"
 
 [extras]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
@@ -73,4 +76,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Random", "Shapefile", "Statistics", "Test", "CairoMakie", "DelimitedFiles", "ImageInTerminal", "Unitful", "DynamicQuantities"]
+test = ["Random", "Shapefile", "Statistics", "Test", "CairoMakie", "DataFrames", "DelimitedFiles", "ImageInTerminal", "Unitful", "DynamicQuantities"]

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -23,6 +23,7 @@ using KernelDensity: kde, pdf
 using StatsBase: fit, histrange, Histogram, normalize, sturges, StatsBase
 
 import Accessors
+import DataAPI
 import GLM, Loess
 import FileIO
 import RelocatableFolders

--- a/src/algebra/select.jl
+++ b/src/algebra/select.jl
@@ -49,7 +49,8 @@ select(data, d::DimsSelector) = (d,) => identity => "" => nothing
 
 function select(data::Columns, name::Union{Symbol, AbstractString})
     v = getcolumn(data.columns, Symbol(name))
-    label = if "label" in DataAPI.colmetadatakeys(data.columns, name)
+    supports_colmetadata = DataAPI.colmetadatasupport(typeof(data.columns)).read
+    label = if supports_colmetadata && "label" in DataAPI.colmetadatakeys(data.columns, name)
         to_string(DataAPI.colmetadata(data.columns, name, "label"))
     else
         to_string(name)

--- a/src/algebra/select.jl
+++ b/src/algebra/select.jl
@@ -49,7 +49,12 @@ select(data, d::DimsSelector) = (d,) => identity => "" => nothing
 
 function select(data::Columns, name::Union{Symbol, AbstractString})
     v = getcolumn(data.columns, Symbol(name))
-    return (v,) => identity => to_string(name) => nothing
+    label = if "label" in DataAPI.colmetadatakeys(data.columns, name)
+        to_string(DataAPI.colmetadata(data.columns, name, "label"))
+    else
+        to_string(name)
+    end
+    return (v,) => identity => label => nothing
 end
 
 function select(data::Columns, idx::Integer)

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -56,6 +56,37 @@ end
     @test_throws_message "not allowed to use arrays that are not one-dimensional" AlgebraOfGraphics.process_mappings(layer)
 end
 
+@testset "column labels processing" begin
+    df = DataFrames.DataFrame(
+        t = 1:10,
+        v = sin.(1:10),
+        c = sqrt.(1:10),
+    )
+
+    layer = data(df) * mapping(:t, :v, color = :c) * visual(Scatter)
+
+    processedlayer = AlgebraOfGraphics.process_mappings(layer)
+    @test processedlayer.labels[1] == fill("t")
+    @test processedlayer.labels[2] == fill("v")
+    @test processedlayer.labels[:color] == fill("c")
+
+    DataFrames.colmetadata!(df, :t, "label", "Time")
+    DataFrames.colmetadata!(df, :v, "label", "Volume")
+    DataFrames.colmetadata!(df, :c, "label", "Concentration")
+
+    processedlayer = AlgebraOfGraphics.process_mappings(layer)
+    @test processedlayer.labels[1] == fill("Time")
+    @test processedlayer.labels[2] == fill("Volume")
+    @test processedlayer.labels[:color] == fill("Concentration")
+
+    layer = data(df) * mapping(:t => "T", :v => "V", color = :c => "C") * visual(Scatter)
+
+    processedlayer = AlgebraOfGraphics.process_mappings(layer)
+    @test processedlayer.labels[1] == fill("T")
+    @test processedlayer.labels[2] == fill("V")
+    @test processedlayer.labels[:color] == fill("C")
+end
+
 @testset "plain `mapping`" begin
     layer = mapping(1:3, 4:6, text = fill("hello", 3) => verbatim)
     processedlayer = AlgebraOfGraphics.process_mappings(layer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ import Unitful
 import DynamicQuantities
 const U = Unitful
 const D = DynamicQuantities
+import DataFrames
 
 Random.seed!(1234)
 


### PR DESCRIPTION
Makes it more convenient to work with table data that has column label metadata attached:

```julia
using AlgebraOfGraphics
using CairoMakie
using DataFrames
using Unitful

df = DataFrame(
    t = 1:10,
    v = sin.(1:10),
    c = sqrt.(1:10) .* u"mg/L",
)

colmetadata!(df, :t, "label", "Time")
colmetadata!(df, :v, "label", "Volume")
colmetadata!(df, :c, "label", "Concentration")


data(df) * mapping(:t, :v, color = :c) * visual(Scatter) |> draw
```

<img width="588" alt="image" src="https://github.com/user-attachments/assets/4e48621c-dbff-4c0f-ac14-e0f871a21b75" />

