### PR TITLE
Pregrouped matrices docs

### DIFF
--- a/docs/src/reference/draw.md
+++ b/docs/src/reference/draw.md
@@ -620,9 +620,9 @@ using AlgebraOfGraphics
 using CairoMakie
 
 spec = pregrouped(
-    fill(1:5, 6),
-    fill(11:15, 6),
-    [reshape(sin.(1:25), 5, 5) .+ i for i in 1:6],
+    fill(repeat(1:5, 5), 6),
+    fill(repeat(11:15, inner = 5), 6),
+    [sin.(1:25) .+ i for i in 1:6],
     layout = 1:6 => nonnumeric) * visual(Heatmap)
 
 draw(

--- a/docs/src/tutorials/intro-v.md
+++ b/docs/src/tutorials/intro-v.md
@@ -358,6 +358,29 @@ draw(multidim_pregrouped)
 
 Isn't that impressively little code to get a quick visualization out of multidimensional non-tabular data?
 
+### Experimental: Passing matrices directly
+
+Tables as 1D data structures are somewhat impractical when it comes to 2D data. With `pregrouped`, you can take advantage of the fact that AlgebraOfGraphics allows you to pass multidimensional numeric arrays to Makie as well.
+
+!!! note
+    This feature is considered experimental as it is a side effect from implementation details and the rules are not really fleshed out, yet.
+
+```@example tut
+ns = 3:8
+xs = [range(0, 3, n+1) for n in ns]
+ys = [range(2, 5, n+1) for n in ns]
+matrices = [randn(n, n) for n in ns]
+
+spec = pregrouped(
+    xs,
+    ys,
+    matrices,
+    layout = dims(1) => renamer(string.(ns))
+) * visual(Heatmap)
+
+draw(spec)
+```
+
 ## Summary
 
 In this chapter you have seen alternative ways of passing input data to AoG, circumventing `data` by passing columns to `mapping` directly, supplying additional columns using `direct`, as well as using multidimensional wide and pregrouped data.


### PR DESCRIPTION
Closes https://github.com/MakieOrg/AlgebraOfGraphics.jl/issues/267

Clarifies that the passing of 2D data via `pregrouped` must be seen as experimental, as the rules for this are a bit unclear, yet. Just because it happens to work for some cases does not mean it was intended to or will be supported. I have seen some uses in the wild, though, so an explicit mention seems warranted.