### PR TITLE
Auto categoricals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Always treat `layout`, `row`, `col` and `group` mappings as categorical to simplify common scenarios where grouping information is stored as integers [#681](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/681).
+- Make `mapping(key = (:col1, :col2))` work automatically, equivalent to `(:col1, :col2) => tuple` [#681](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/681).
+
 ## v0.11.4 - 2025-08-15
 
 - Bumped julia compat to `1.10` to match Makie going forward.

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -410,7 +410,7 @@ function rescale(p::ProcessedLayer, categoricalscales::MultiAesScaleDict{Categor
             scale_id = get(p.scale_mapping, key, nothing)
             scale_dict = get(categoricalscales, aes, nothing)
             scale = scale_dict === nothing ? nothing : get(scale_dict, scale_id, nothing)
-            return rescale(values, scale)
+            return rescale(values, scale; allow_continuous = false) # we know these aesthetics are always categorical so we don't the option to mix continuous into it here (like drawing a scatter dot at 1.5 between A and B)
         else
             return values
         end
@@ -466,7 +466,9 @@ function concatenate(pls::AbstractVector{ProcessedLayer})
 end
 
 function append_processedlayers!(pls_grid, processedlayer::ProcessedLayer, categoricalscales::MultiAesScaleDict{CategoricalScale})
+    @show processedlayer.primary
     processedlayer = rescale(processedlayer, categoricalscales)
+    @show processedlayer.primary
     tmp_pls_grid = map(_ -> ProcessedLayer[], pls_grid)
     for c in CartesianIndices(shape(processedlayer))
         pl = slice(processedlayer, c)

--- a/src/algebra/processing.jl
+++ b/src/algebra/processing.jl
@@ -153,7 +153,9 @@ function process_mappings(layer::Layer)
     unique_scales_without_nothings = filter(x -> x isa ScaleID, unique_scales)
     scale_mapping = map(scaleid -> scaleid.id, unique_scales_without_nothings)
 
-    primary, named = separate(iscategoricalcontainer, named)
+    # we know that the hardcoded mappings are categorical, so we can just always sort
+    # those into primary even if users pass something like integers, which is very common
+    primary, named = separate_by_key_value((k, v) -> hardcoded_mapping(k) !== nothing || iscategoricalcontainer(v), named)
 
     return ProcessedLayer(; primary, positional, named, labels, scale_mapping)
 end

--- a/src/algebra/select.jl
+++ b/src/algebra/select.jl
@@ -115,6 +115,9 @@ function select(data::Columns, direct::DirectData{T}) where {T}
     return (arr,) => identity => "" => nothing
 end
 
+# treat a tuple of columns as a column of tuples by default
+select(data, x::Tuple{Vararg{Union{Symbol,String}}}) = select(data, x => tuple)
+
 function select(data, x::Pair{<:Any, <:Any})
     name, transformation = x
     if name isa Tuple

--- a/src/algebra/select.jl
+++ b/src/algebra/select.jl
@@ -116,7 +116,7 @@ function select(data::Columns, direct::DirectData{T}) where {T}
 end
 
 # treat a tuple of columns as a column of tuples by default
-select(data, x::Tuple{Vararg{Union{Symbol,String}}}) = select(data, x => tuple)
+select(data, x::Tuple{Vararg{Union{Symbol, String}}}) = select(data, x => tuple)
 
 function select(data, x::Pair{<:Any, <:Any})
     name, transformation = x

--- a/src/dict.jl
+++ b/src/dict.jl
@@ -12,10 +12,10 @@ function filterkeys(f, d::AbstractDictionary)
     return getindices(d, idxs)
 end
 
-function separate(f, d::AbstractDictionary)
+function separate_by_key_value(f, d::AbstractDictionary)
     d1, d2 = empty(d), empty(d)
     for (k, v) in pairs(d)
-        target = ifelse(f(v), d1, d2)
+        target = ifelse(f(k, v), d1, d2)
         insert!(target, k, v)
     end
     return d1, d2

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -505,11 +505,14 @@ elementwise_rescale(value) = value
 
 contextfree_rescale(values) = map(elementwise_rescale, values)
 
-rescale(values, ::Nothing) = values
+rescale(values, ::Nothing; allow_continuous = true) = values
 
-function rescale(values, c::CategoricalScale)
+function rescale(values, c::CategoricalScale; allow_continuous = true)
     # Do not rescale continuous data with categorical scale
-    scientific_eltype(values) === categorical || return values
+    if allow_continuous && scientific_eltype(values) !== categorical
+        # this can be useful to allow plotting values in between categories, but should be used carefully, more like an escape hatch really
+        return values
+    end
     idxs = indexin(values, datavalues(c))
     for (i, idx) in zip(eachindex(values), idxs)
         if idx === nothing

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -266,3 +266,26 @@ end
     @test e2.named[:align] == aligns[6:10]
     @test e2.named[:color] == colors[6:10]
 end
+
+@testset "hardcoded categoricals work with continuous data" begin
+
+    hardcodeds = [:layout, :col, :row, :group]
+
+    for hardcoded in hardcodeds
+        aes = AlgebraOfGraphics.hardcoded_mapping(hardcoded)
+        @test aes !== nothing
+        fg = draw(mapping(1:3, 1:3; (; hardcoded => [3, 1, 2])...))
+        sc = fg.grid[1].categoricalscales[aes][nothing]
+        @test AlgebraOfGraphics.datavalues(sc) == [1, 2, 3]
+        expected_palette = hardcoded === :layout ? [(1, 1), (1, 2), (2, 1)] : 1:3
+        @test AlgebraOfGraphics.plotvalues(sc) == expected_palette
+    end
+end
+@testset "tuples of columns can be passed without transform func" begin
+    spec = data((; x = 1:4, y = 1:4, a = [2, 1, 1, 2], b = [4, 4, 3, 3])) *
+        mapping(:x, :y, row = (:a, :b))
+    fg = draw(spec)
+    sc = fg.grid[1].categoricalscales[AlgebraOfGraphics.AesRow][nothing]
+    @test AlgebraOfGraphics.datavalues(sc) == [(1, 3), (1, 4), (2, 3), (2, 4)]
+    @test AlgebraOfGraphics.plotvalues(sc) == 1:4
+end

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -100,12 +100,6 @@ end
     @test processedlayer.named[:text] == fill(verbatim.(fill("hello", 3)))
 end
 
-@testset "Invalid use of continuous for categorical hardcoded mapping" begin
-    df = (x = 1:4, y = 1:4, page = [1, 1, 2, 2], color = ["A", "B", "C", "D"])
-    spec = data(df) * mapping(:x, :y, color = :color, layout = :page) * visual(Scatter)
-    @test_throws_message "The `layout` mapping was used with continuous data" draw(spec)
-end
-
 @testset "shape" begin
     df = (x = rand(1000), y = rand(1000), z = rand(1000), c = rand(["a", "b", "c"], 1000))
     d = mapping(:x => exp, [:y, :z], color = :c, marker = dims(1) => renamer(["a", "b"]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using AlgebraOfGraphics, Makie, Random, Statistics, Test, Dates
 
 using AlgebraOfGraphics: Sorted, Presorted
-using AlgebraOfGraphics: separate
+using AlgebraOfGraphics: separate_by_key_value
 using AlgebraOfGraphics: midpoints
 using AlgebraOfGraphics: apply_palette
 using AlgebraOfGraphics: datavalues

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -40,6 +40,11 @@ end
     @test odd == NamedArguments((a = 1, c = 3))
     @test even == NamedArguments((b = 2,))
 
+    s = NamedArguments([:a, :b, :c], [1, 2, 3])
+    is_a, is_not_a = separate_by_key_value((k, v) -> k == :a, s)
+    @test is_a == NamedArguments((a = 1,))
+    @test is_not_a == NamedArguments((b = 2, c = 3))
+
     t = AlgebraOfGraphics.set(s, :d => 5, :a => 3)
     @test t == NamedArguments([:a, :b, :c, :d], [3, 2, 3, 5])
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -36,7 +36,7 @@ end
     )
 
     s = NamedArguments([:a, :b, :c], [1, 2, 3])
-    odd, even = separate(isodd, s)
+    odd, even = separate_by_key_value((k, v) -> isodd(v), s)
     @test odd == NamedArguments((a = 1, c = 3))
     @test even == NamedArguments((b = 2,))
 


### PR DESCRIPTION
This PR makes it more convenient to use the standard forced-categorical mappings `layout`, `row`, `col` and `group` with data whose type AoG doesn't consider categorical. Before, we just errored and said "make your data categorical" but this is a rather redundant step if we know the only correct answer. Of course, users could inadvertently pass a completely wrong column with many different float values which gets them 100 facets now, but there's always ways to shoot yourself in the foot if you're not careful.

It's fairly common to have dataframes with some grouping data in numerical format. Before, you'd get this:

```julia
df = (; x = 1:10, y = 11:20, group = [1, 2, 3, 2, 3, 2, 1, 1, 2, 3])
data(df) * mapping(:x, :y, layout = :group) * visual(Scatter) |> draw
```

```
ERROR: The `layout` mapping was used with continuous data but can only be used with categorical data. Consider using the `=> nonnumeric` modifier to turn numerical data into categorical.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] (::AlgebraOfGraphics.var"#64#65"{…})(key::Symbol, val::Vector{…})
    @ AlgebraOfGraphics ~/.julia/dev/AlgebraOfGraphics/src/algebra/layer.jl:308
  [3] map!(f::AlgebraOfGraphics.var"#64#65"{…}, out::Dictionaries.Dictionary{…}, d::Dictionaries.Indices{…}, d2::Dictionaries.Dictionary{…})
```

Now, you just get the expected plot directly:

<img width="510" height="382" alt="image" src="https://github.com/user-attachments/assets/bfce3dea-9fa6-472e-83c9-f6a3260a14cf" />

For other aesthetics like color etc. the user is still responsible to pass the right type themselves, we cannot guess what's intended to be categorical even though it looks continuous.

This PR also adds a little bit of convenience for another common situation that was related, where a tuple of columns is passed as a quick grouping. This used to error:

```julia
df = (; x = 1:10, y = 11:20, group1 = repeat(1:2, inner = 5), group2 = repeat(1:5, 2))
data(df) * mapping(:x, :y, layout = (:group1, :group2)) * visual(Scatter) |> draw
```

```
ERROR: MethodError: no method matching select(::AlgebraOfGraphics.Columns{@NamedTuple{…}}, ::Tuple{Symbol, Symbol})
The function `select` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  select(::Nothing, ::Any, ::Any)
   @ AlgebraOfGraphics ~/.julia/dev/AlgebraOfGraphics/src/algebra/select.jl:66
  select(::AlgebraOfGraphics.Columns, ::Union{AbstractString, Symbol})
```

And now also just works:

<img width="500" height="383" alt="image" src="https://github.com/user-attachments/assets/97eb066e-a404-4fd6-915a-26d43f3c6b16" />
