### PR TITLE
Add links to definition of "tidy" data

### DIFF
--- a/docs/src/examples/data-manipulations/wide-data.md
+++ b/docs/src/examples/data-manipulations/wide-data.md
@@ -4,7 +4,7 @@ AlgebraOfGraphics works with both long and wide data formats. Understanding the 
 
 ## What is Long Format?
 
-In long format (also called "tidy" format), each row represents one observation. If you have multiple groups or categories, they're indicated by values in a categorical column rather than spread across separate columns.
+In long format (also called ["tidy"](https://tidyr.tidyverse.org/articles/tidy-data.html) format), each row represents one observation. If you have multiple groups or categories, they're indicated by values in a categorical column rather than spread across separate columns.
 
 Here's an example of long format data:
 

--- a/docs/src/tutorials/intro-i.md
+++ b/docs/src/tutorials/intro-i.md
@@ -26,7 +26,7 @@ Here's a short overview of similarities and differences between ggplot2 and Alge
 |Defines all of the visual infrastructure itself, outputs low level graphics objects that are hard to modify directly.|Creates high-level Makie building blocks like `Figure`, `Axis` or `Legend` as well as plot objects like `Lines` or `Scatter` which can be modified more easily.|
 |`geom`s specify visual components and `stats` statistical transformations, but some `geoms` have default `stat`s and vice versa | Layers with the `visual` transformation feed their associated data directly to Makie plotting functions. Layers with other `transformation`s apply more complex modifications to the data first and can result in multiple output layers.|
 
-AlgebraOfGraphics primarily works with long format data, where each row is one observation and columns represent variables. For example, the penguins dataset we'll use has one row per penguin, with columns like `bill_length_mm` and `species`. Wide format data (where multiple measurements are spread across columns) is also supported. If you're wondering about the difference between long and wide formats, see [Long vs Wide Data Formats](@ref) for a detailed comparison with examples.
+AlgebraOfGraphics primarily works with long format ("tidy")[https://tidyr.tidyverse.org/articles/tidy-data.html] data, where rows are observations and columns are variables. For example, the penguins dataset we'll use has one row per penguin, with columns like `bill_length_mm` and `species`. Wide format data (where multiple measurements are spread across columns) is also supported. If you're wondering about the difference between long and wide formats, see [Long vs Wide Data Formats](@ref) for a detailed comparison with examples.
 
 ## Preparations
 

--- a/docs/src/tutorials/intro-v.md
+++ b/docs/src/tutorials/intro-v.md
@@ -1,6 +1,6 @@
 # Intro to AoG - V - Alternative input data formats
 
-So far, every example you've seen in this tutorial series was using a long-format or "tidy" dataframe in the tradition of ggplot2.
+So far, every example you've seen in this tutorial series was using a long-format or ["tidy"](https://tidyr.tidyverse.org/articles/tidy-data.html) dataframe in the tradition of ggplot2.
 
 Sometimes, however, our data does not come in this format, and we don't want to spend the time to transform it before we start plotting. In this case, it's good to be aware of alternative methods of specifying and handling input data that AlgebraOfGraphics offers.
 


### PR DESCRIPTION
While reading (admittedly only the first few posts) of https://discourse.julialang.org/t/algebraofgraphics-documentation-frustrations/133903 

I had a look at the docs and noticed that the tidy folks have a nice explanation of the data format and added a  few links to it from the documentation