### PR TITLE
Add contents method for FigureGrid

### DIFF
--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -30,6 +30,7 @@ import RelocatableFolders
 import PolygonOps
 import Isoband
 import NaturalSort
+import GridLayoutBase
 
 export hideinnerdecorations!, deleteemptyaxes!
 export Layer, Layers, ProcessedLayer, ProcessedLayers, zerolayer

--- a/src/entries.jl
+++ b/src/entries.jl
@@ -92,3 +92,5 @@ end
 
 Base.iterate(fg::FigureGrid) = iterate((fg.figure, fg.grid))
 Base.iterate(fg::FigureGrid, i) = iterate((fg.figure, fg.grid), i)
+
+GridLayoutBase.contents(fg::FigureGrid) = contents(fg.figure.layout)


### PR DESCRIPTION
Adds a new method to contents function from GridLayoutBase which takes a FigureGrid as the sole argument.