### PR TITLE
fix(facet): Propagate datetime ticks to empty facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed legend labels missing when a layer only exists in non-first facets [#721](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/721).
 - Fixed `smooth()`, `linear()` and `histogram()` failing with `Date`/`DateTime` axes [#724](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/724).
 - Delegate datetime tick computation to Makie's `DateTimeTicks`, which provides better tick placement and context-aware label formatting (e.g., showing only the time when the date hasn't changed between ticks). Ticks now also update dynamically when zooming/panning. Requires Makie >= 0.24.4 [#725](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/725).
+- Fixed empty facets showing raw float values instead of datetime tick labels when sharing a datetime axis with non-empty facets [#726](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/726).
 
 ## v0.12.1 - 2026-01-07
 


### PR DESCRIPTION
## Summary

- Fixes empty facets in `facet_grid` showing raw float values instead of datetime tick labels when sharing a datetime axis with non-empty facets (#471)
- When a facet has no layers but there's a single merged continuous scale for that axis, propagates its ticks to the empty facet
- Errors clearly if multiple candidate scales exist and the correct one can't be determined

## Test plan

- [x] Unit test: single merged datetime scale correctly assigns `DateTicksWrapper` to empty facet
- [x] Unit test: multiple candidate scales produces a clear error with scale names
- [x] Full test suite passes

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>