### PR TITLE
feat(facet): Add FacetSize and aspect-aware wrap layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `FacetSize(aspect, height_fn)` and `facet = (; size = FacetSize(...))` for declaring an axis sizing policy that adapts to the resolved grid layout. The default `wrapped()` palette is now lazy and resolves to `(row, col)` positions at draw time using the effective axis aspect (from `FacetSize` or user-supplied width+height, defaulting to 1.0). For square axes this preserves the prior `ceil(sqrt(n))` behavior; non-square aspects pick a column count that brings the bunched axis areas closest to a square shape [#745](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/745).
+
 ## v0.12.6 - 2026-03-30
 
 - Legend entries now hide elements from plot types that have no data for a given category (`hide_unused` defaults to `true`). This fixes misleading legends when layers with different plot types share a categorical scale but cover different subsets of categories (e.g., Scatter for "A" and Lines for "B" no longer both show a marker+line for every entry). The behavior can be controlled globally via `legend = (; hide_unused = false)` in `draw`, or per scale via `scales(Color = (; hide_unused_legend = false))`. Paginated plots also benefit, as each page's legend now only shows categories present on that page [#742](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/742).

--- a/docs/src/examples/layout/faceting.md
+++ b/docs/src/examples/layout/faceting.md
@@ -63,6 +63,52 @@ draw(plt, facet=(; linkxaxes=:none, linkyaxes=:none))
 draw(plt, scales(Layout = (; palette = [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2)])))
 ````
 
+## Sizing facets
+
+By default, all facets share the figure size that Makie picks for `Figure`. With many facets that's often too cramped: axes get squeezed, labels overlap, and the figure can't grow because no axis has an explicit `width`/`height`.
+
+You can pass a per-axis `width` and `height` directly via `axis = (; width, height)`, in which case the figure will resize to fit:
+
+````@example faceting
+draw(plt; axis = (; width = 100, height = 100))
+````
+
+Often, though, the right size depends on how many facets there are. For that, AoG provides `FacetSize`:
+
+````@example faceting
+fs = FacetSize(1.0, (n_rows, n_cols) -> max(n_rows, n_cols) <= 2 ? 200 : 100)
+draw(plt; facet = (; size = fs))
+````
+
+`FacetSize(aspect, height_fn)` packages two pieces of information:
+
+- `aspect` (axis width / height) — used upfront when computing the wrap layout, so wide axes get fewer columns and tall axes get more (see [Aspect-aware wrap](@ref) below).
+- `height_fn(n_rows, n_cols) -> Int` — runs after the grid is determined and returns the per-axis height. Width is derived as `aspect * height`.
+
+This lets you write a single sizing policy that adapts to the data. The example above gives a `200×200` axis when there are at most 2 rows or columns, and shrinks to `100×100` for larger grids.
+
+You can still override `width` or `height` (or both) via `axis`. If you supply only one dimension, the other is derived from `FacetSize`'s aspect; if you supply both, your aspect takes over (and the `height_fn` is ignored):
+
+````@example faceting
+draw(plt; facet = (; size = fs), axis = (; width = 200))
+````
+
+## Aspect-aware wrap
+
+When `wrapped()` is the default `Layout` palette (i.e. you don't pass `cols`, `rows`, or a custom palette), the row/column distribution is decided at draw time using the effective axis aspect ratio. The aspect comes from `FacetSize` if provided, otherwise from `axis = (; width, height)` if both are given, otherwise it defaults to `1.0` — which reproduces the prior squareish wrap (`ceil(sqrt(n))` columns).
+
+For non-square axes, the wrap picks a column count that brings the bunched axis areas closest to a square shape. With the same 5 facets above, wide axes prefer fewer columns:
+
+````@example faceting
+draw(plt; facet = (; size = FacetSize(2.0, (nr, nc) -> 100)))
+````
+
+and tall axes prefer more columns:
+
+````@example faceting
+draw(plt; facet = (; size = FacetSize(0.5, (nr, nc) -> 200)))
+````
+
 ## Adding traces to only some subplots
 
 ````@example faceting

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -48,6 +48,7 @@ export direct
 export from_continuous
 export wrapped
 export clipped
+export FacetSize
 export show_aesthetics
 
 include("dict.jl")

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -277,10 +277,10 @@ end
 
 function compute_axes_grid(
         fig, d::AbstractDrawable, scales::Scales = scales();
-        axis = NamedTuple()
+        axis = NamedTuple(), facet = NamedTuple()
     )
 
-    axes_grid = compute_axes_grid(d, scales; axis)
+    axes_grid = compute_axes_grid(d, scales; axis, facet)
     sz = size(axes_grid)
     if sz != (1, 1) && fig isa Axis
         msg = "You can only pass an `Axis` to `draw!` if the calculated layout only contains one element. Elements: $(sz)"
@@ -311,7 +311,46 @@ function hardcoded_or_mapped_aes(processedlayer, key::Union{Int, Symbol}, aes_ma
     return aes_mapping[key]
 end
 
-function compute_axes_grid(d::AbstractDrawable, scales::Scales = scales(); axis = NamedTuple())
+# Resolve any *deferred* (linear-index) Layout scale positions into proper `(row, col)`
+# tuples using the given `aspect`. Replaces the Layout entry in `categoricalscales` with
+# fresh `CategoricalScale`s whose `plot` field holds tuples.
+function _resolve_lazy_layout!(categoricalscales::MultiAesScaleDict{CategoricalScale}, aspect::Real)
+    haskey(categoricalscales, AesLayout) || return
+    scaledict = categoricalscales[AesLayout]
+    for (key, scale) in pairs(scaledict)
+        plot = scale.plot
+        eltype(plot) <: Integer || continue  # already resolved
+        new_plot = resolve_lazy_wrap(plot, length(plot), aspect)
+        scaledict[key] = CategoricalScale(scale.data, new_plot, scale.label, scale.props, scale.aes)
+    end
+    return
+end
+
+# Apply `facet_size` to populate `axis_dict[:width]` / `axis_dict[:height]`.
+# User-supplied `width`/`height` already in `axis_dict` take precedence.
+function _apply_facet_size!(axis_dict, facet_size::FacetSize, n_rows::Int, n_cols::Int)
+    user_w = get(axis_dict, :width, nothing)
+    user_h = get(axis_dict, :height, nothing)
+    aspect = facet_size.aspect
+    if user_w isa Number && user_h isa Number
+        return  # both supplied, nothing to do
+    elseif user_w isa Number
+        insert!(axis_dict, :height, round(Int, user_w / aspect))
+    elseif user_h isa Number
+        insert!(axis_dict, :width, round(Int, user_h * aspect))
+    else
+        h = facet_size.height(n_rows, n_cols)
+        insert!(axis_dict, :height, h)
+        insert!(axis_dict, :width, round(Int, h * aspect))
+    end
+    return
+end
+
+function compute_axes_grid(d::AbstractDrawable, scales::Scales = scales(); axis = NamedTuple(), facet = NamedTuple())
+
+    # Extract optional `facet_size::FacetSize`. User-supplied `width`/`height` in `axis` take precedence.
+    axis_dict::NamedArguments = axis isa NamedArguments ? copy(axis) : dictionary(pairs(axis))
+    facet_size = get(facet, :size, nothing)
 
     processedlayers = ProcessedLayers(d).layers
 
@@ -342,12 +381,36 @@ function compute_axes_grid(d::AbstractDrawable, scales::Scales = scales(); axis 
         map!(fitscale, scaledict, scaledict)
     end
 
+    # Resolve any deferred (linear-index) Layout positions to (row, col) using the effective aspect:
+    #   1. User-supplied `width` and `height` in `axis` (both required)
+    #   2. `FacetSize.aspect` if `facet_size` is a `FacetSize`
+    #   3. `1.0` (matches the prior squareish wrap)
+    layout_aspect = let
+        user_w = get(axis_dict, :width, nothing)
+        user_h = get(axis_dict, :height, nothing)
+        if user_w isa Number && user_h isa Number
+            user_w / user_h
+        elseif facet_size isa FacetSize
+            facet_size.aspect
+        else
+            1.0
+        end
+    end
+    _resolve_lazy_layout!(categoricalscales, layout_aspect)
+
     set_dodge_width_default!(categoricalscales, processedlayers)
     compute_plot_dependent_attributes!(processedlayers)
 
     pls_grid = compute_processedlayers_grid(processedlayers, categoricalscales)
     entries_grid, continuousscales_grid, merged_continuousscales =
         compute_entries_continuousscales(pls_grid, categoricalscales, scale_props)
+
+    # Apply `facet_size` now that we know the grid dimensions
+    if facet_size !== nothing
+        n_rows, n_cols = size(pls_grid)
+        _apply_facet_size!(axis_dict, facet_size, n_rows, n_cols)
+    end
+    final_axis = axis_dict
 
     indices = CartesianIndices(pls_grid)
     axes_grid = map(indices) do c
@@ -363,7 +426,7 @@ function compute_axes_grid(d::AbstractDrawable, scales::Scales = scales(); axis 
         end
 
         return AxisSpecEntries(
-            AxisSpec(c, axis),
+            AxisSpec(c, final_axis),
             entries_grid[c],
             categoricalscales,
             mixed_continuousscales,

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -183,13 +183,34 @@ function _draw(
         axis, figure, facet, legend, colorbar
     )
 
-    ae = compute_axes_grid(d, scales; axis)
+    ae = compute_axes_grid(d, scales; axis, facet)
+    # `facet_size` was applied inside `compute_axes_grid`; strip it so `_draw(ae)` doesn't reapply.
+    if haskey(facet, :size)
+        facet = copy(facet)
+        delete!(facet, :size)
+    end
     return _draw(ae; figure, facet, legend, colorbar)
 end
 
 function _draw(ae::Matrix{AxisSpecEntries}; axis = Dictionary{Symbol, Any}(), figure = Dictionary{Symbol, Any}(), facet = Dictionary{Symbol, Any}(), legend = Dictionary{Symbol, Any}(), colorbar = Dictionary{Symbol, Any}())
 
-    if !isempty(axis)
+    facet_size = get(facet, :size, nothing)
+    if facet_size !== nothing
+        facet = copy(facet)
+        delete!(facet, :size)
+    end
+
+    # Apply `axis` overrides and/or `facet_size` to the AxisSpecs. This runs for paginated draws
+    # (where axis kwargs and facet_size were not yet consumed by `compute_axes_grid`) and for
+    # non-paginated with explicit user axis overrides. For non-paginated without overrides, `axis`
+    # is empty and `facet_size` is nothing here (already applied in `compute_axes_grid`).
+    if !isempty(axis) || facet_size !== nothing
+        axis = copy(axis)
+        if facet_size !== nothing
+            n_rows, n_cols = size(ae)
+            _apply_facet_size!(axis, facet_size, n_rows, n_cols)
+        end
+
         # merge in axis attributes here because pagination runs `compute_axes_grid`
         # which in the normal `draw` pipeline consumes `axis`
         ae = map(ae) do ase

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -192,7 +192,7 @@ function _draw(
     return _draw(ae; figure, facet, legend, colorbar)
 end
 
-function _draw(ae::Matrix{AxisSpecEntries}; axis = Dictionary{Symbol, Any}(), figure = Dictionary{Symbol, Any}(), facet = Dictionary{Symbol, Any}(), legend = Dictionary{Symbol, Any}(), colorbar = Dictionary{Symbol, Any}())
+function _draw(ae::Matrix{AxisSpecEntries}; axis = Dictionary{Symbol, Any}(), figure = Dictionary{Symbol, Any}(), facet = Dictionary{Symbol, Any}(), legend = Dictionary{Symbol, Any}(), colorbar = Dictionary{Symbol, Any}(), facet_size_grid::Union{Nothing, NTuple{2, Int}} = nothing)
 
     facet_size = get(facet, :size, nothing)
     if facet_size !== nothing
@@ -207,7 +207,9 @@ function _draw(ae::Matrix{AxisSpecEntries}; axis = Dictionary{Symbol, Any}(), fi
     if !isempty(axis) || facet_size !== nothing
         axis = copy(axis)
         if facet_size !== nothing
-            n_rows, n_cols = size(ae)
+            # When called from a `Pagination`, `facet_size_grid` is the max grid size across all
+            # pages so trailing pages get the same axis size as full pages.
+            n_rows, n_cols = facet_size_grid === nothing ? size(ae) : facet_size_grid
             _apply_facet_size!(axis, facet_size, n_rows, n_cols)
         end
 

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -32,7 +32,10 @@ function draw(p::Pagination; axis = (;), figure = (;), facet = (;), legend = (;)
     facet = _kwdict(facet, :facet)
     legend = _kwdict(legend, :legend)
     colorbar = _kwdict(colorbar, :colorbar)
-    return _draw.(p.each; axis, figure, facet, legend, colorbar)
+    # Use max grid size across all pages so a `facet = (; size = ...)` policy gives every page
+    # (including the trailing one) the same axis size.
+    facet_size_grid = _max_grid_size(p)
+    return _draw.(p.each; axis, figure, facet, legend, colorbar, facet_size_grid)
 end
 
 """
@@ -52,7 +55,15 @@ function draw(p::Pagination, i::Int; axis = (;), figure = (;), facet = (;), lege
     facet = _kwdict(facet, :facet)
     legend = _kwdict(legend, :legend)
     colorbar = _kwdict(colorbar, :colorbar)
-    return _draw(p.each[i]; axis, figure, facet, legend, colorbar)
+    facet_size_grid = _max_grid_size(p)
+    return _draw(p.each[i]; axis, figure, facet, legend, colorbar, facet_size_grid)
+end
+
+# Max grid size across all pages, used for cross-page-consistent facet sizing.
+function _max_grid_size(p::Pagination)
+    rows = maximum(page -> size(page, 1), p.each)
+    cols = maximum(page -> size(page, 2), p.each)
+    return (rows, cols)
 end
 
 function draw(p::Pagination, ::Scales, args...; kws...)
@@ -134,7 +145,14 @@ function paginate_axes_grid(agrid::Matrix{AxisSpecEntries}; layout = nothing, ro
 
         for groupindices in Iterators.partition(eachindex(dvalues, pvalues), layout)
             palette = something(scale.props.palette, wrapped())
-            wrapped_positions = apply_palette(palette, 1:length(groupindices))
+            raw_positions = apply_palette(palette, 1:length(groupindices))
+            # The default `Wrap{Automatic}` palette returns linear indices that need to be
+            # resolved to (row, col). Other palettes (custom Wrap, vectors) already return tuples.
+            wrapped_positions = if eltype(raw_positions) <: Integer
+                resolve_lazy_wrap(raw_positions, length(groupindices), 1.0)
+            else
+                raw_positions
+            end
 
             props = scale.props
             sliced_scale = CategoricalScale(

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -170,7 +170,9 @@ end
 # fewer columns and tall axes get more.
 function resolve_lazy_wrap(linear_idxs::AbstractVector{<:Integer}, total::Integer, aspect::Real, by_col::Bool = false)
     target_cols = sqrt(total / aspect)
-    candidates = (max(1, floor(Int, target_cols)), ceil(Int, target_cols))
+    # Order candidates so that on a tie (equal log-distance) `argmin` picks the larger column count.
+    # This matches the prior `ceil(sqrt(n))` behavior for square axes (e.g. n=2 → 1×2, not 2×1).
+    candidates = (ceil(Int, target_cols), max(1, floor(Int, target_cols)))
     distance(c) = abs(log(c * aspect / ceil(Int, total / c)))
     ncols = candidates[argmin(distance.(candidates))]
     f(ij) = by_col ? reverse(ij) : ij

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -129,8 +129,10 @@ end
 
 Create an object that can be passed to the `Layout` scale `palette` which controls how many
 rows or columns are allowed at maximum in the wrapped layout. Only one of `cols` or `rows` may
-be set to an integer at the same time. If both are `automatic`, a squareish configuration is chosen.
-If `by_col` is to `true`, the layout is filled top to bottom first and then column by column.
+be set to an integer at the same time. If both are `automatic`, the wrap is *deferred*: positions
+are produced as linear indices and resolved to `(row, col)` later when the axis aspect ratio is
+known (from a `FacetSize`, defaulting to `1` which reproduces the prior squareish wrapping).
+If `by_col` is `true`, the layout is filled top to bottom first and then column by column.
 """
 function wrapped(;
         cols::Union{Integer, Makie.Automatic} = Makie.automatic,
@@ -148,15 +150,51 @@ function wrapped(;
     end
 end
 
+# Default Wrap is *deferred*: returns linear indices to be resolved later in `compute_axes_grid`
+# once the axis aspect ratio (from `FacetSize`) is known.
 function apply_palette(w::Wrap{Automatic}, uv)
-    ncols = ceil(Int, sqrt(length(uv)))
-    return apply_palette(Wrap((n = ncols, cols = true), w.by_col), uv)
+    return collect(eachindex(uv))
 end
 
 function apply_palette(w::Wrap{@NamedTuple{n::Int64, cols::Bool}}, uv)
     n = w.size_restriction.cols != w.by_col ? w.size_restriction.n : ceil(Int, length(uv) / w.size_restriction.n)
     f(ij) = w.by_col ? reverse(ij) : ij
     return [f(fldmod1(idx, n)) for idx in eachindex(uv)]
+end
+
+# Resolve a deferred linear-index layout palette into `(row, col)` positions using the axis aspect.
+# `total` is the total number of facets (used to compute the column count).
+# Picks `ncols` so the bunched-together axis areas (cols * axis_w) / (rows * axis_h) are closest
+# to a square shape. With `aspect = 1` this preserves the prior `ceil(sqrt(n))` behavior for
+# common counts (9 → 3×3, 16 → 4×4). For non-square aspects the layout adapts: wide axes get
+# fewer columns and tall axes get more.
+function resolve_lazy_wrap(linear_idxs::AbstractVector{<:Integer}, total::Integer, aspect::Real, by_col::Bool = false)
+    target_cols = sqrt(total / aspect)
+    candidates = (max(1, floor(Int, target_cols)), ceil(Int, target_cols))
+    distance(c) = abs(log(c * aspect / ceil(Int, total / c)))
+    ncols = candidates[argmin(distance.(candidates))]
+    f(ij) = by_col ? reverse(ij) : ij
+    return [f(fldmod1(idx, ncols)) for idx in linear_idxs]
+end
+
+"""
+    FacetSize(aspect, height)
+
+Encodes how to size the axes in a faceted plot:
+- `aspect`: the axis width-to-height ratio (used upfront to choose wrap layout)
+- `height`: a function `(n_rows, n_cols) -> Int` returning the axis height for the resulting grid
+
+When `FacetSize` is passed as `facet = (; size = FacetSize(...))`:
+- The `Layout` scale's wrap palette uses `aspect` for choosing rows/columns.
+- If the user does not supply `width` or `height` in `axis`, both are computed
+  from `aspect` and `height(n_rows, n_cols)`.
+- If the user supplies only `width`, `height` is derived as `width / aspect`.
+- If the user supplies only `height`, `width` is derived as `height * aspect`.
+- If the user supplies both, neither `aspect` nor `height` is used.
+"""
+struct FacetSize
+    aspect::Float64
+    height::Function  # (n_rows, n_cols) -> Int
 end
 
 struct Clipped{C}

--- a/test/facet.jl
+++ b/test/facet.jl
@@ -317,4 +317,23 @@ end
     fg_large = draw(plt_large; facet = (; size = fs_dynamic))
     @test maximum(size(fg_large.grid)) >= 3
     @test first(fg_large.grid).axis.height[] == 80
+
+    # Pagination: all pages (including the trailing one with fewer facets) get the same axis
+    # size because the `height` callback is given the max grid across all pages.
+    df_pag = (; x = repeat(1:5, 9), y = rand(45), g = repeat(string.(1:9), inner = 5))
+    plt_pag = data(df_pag) * mapping(:x, :y, layout = :g) * visual(Lines)
+    # Policy crosses tier at 1×1 vs larger: would give trailing 1×1 page a different size
+    # if AoG sized per-page instead of using the max grid.
+    crossing_policy = AlgebraOfGraphics.FacetSize(1.0, (nr, nc) -> max(nr, nc) == 1 ? 200 : 80)
+    pag = paginate(plt_pag, layout = 4)
+    pages = draw(pag; facet = (; size = crossing_policy))
+    @test length(pages) == 3
+    @test size(pages[1].grid) == (2, 2)
+    @test size(pages[3].grid) == (1, 1)  # trailing page
+    # All pages get the size for the max grid (2×2 → 80), not their own grid
+    for fg in pages
+        @test first(fg.grid).axis.height[] == 80
+    end
+    # Single-page draws use the same max-grid policy
+    @test first(draw(pag, 3; facet = (; size = crossing_policy)).grid).axis.height[] == 80
 end

--- a/test/facet.jl
+++ b/test/facet.jl
@@ -267,3 +267,54 @@ end
     end
     @test isempty(contents(fg.figure[2, 3]))
 end
+
+
+@testset "facet_size" begin
+    df = (; x = repeat(1:5, 10), y = rand(50), g = repeat(string.(1:10), inner = 5))
+    plt = data(df) * mapping(:x, :y, layout = :g) * visual(Lines)
+
+    # FacetSize with no axis overrides: width/height derived from aspect + height function
+    fs = AlgebraOfGraphics.FacetSize(2.0, (nr, nc) -> 100)
+    fg = draw(plt; facet = (; size = fs))
+    ax = first(fg.grid).axis
+    @test ax.height[] == 100
+    @test ax.width[] == 200  # 100 * aspect = 200
+    # Wide aspect → fewer columns (5 rows × 2 cols for n=10, aspect 2)
+    @test size(fg.grid) == (5, 2)
+
+    # User overrides height only: width derived from aspect
+    fg = draw(plt; facet = (; size = fs), axis = (; height = 80))
+    ax = first(fg.grid).axis
+    @test ax.height[] == 80
+    @test ax.width[] == 160
+
+    # User overrides width only: height derived from aspect
+    fg = draw(plt; facet = (; size = fs), axis = (; width = 300))
+    ax = first(fg.grid).axis
+    @test ax.width[] == 300
+    @test ax.height[] == 150  # 300 / aspect = 150
+
+    # User overrides both: aspect/height callback ignored, layout uses user's aspect
+    fg = draw(plt; facet = (; size = fs), axis = (; width = 100, height = 200))
+    ax = first(fg.grid).axis
+    @test ax.width[] == 100
+    @test ax.height[] == 200
+    # User aspect 0.5 (tall) → more columns (2 rows × 5 cols)
+    @test size(fg.grid) == (2, 5)
+
+    # The `height` function is given the resolved grid dimensions, so the same callback can yield
+    # different sizes depending on grid size — useful for tier-based sizing.
+    fs_dynamic = AlgebraOfGraphics.FacetSize(1.0, (nr, nc) -> max(nr, nc) <= 2 ? 200 : 80)
+
+    df_small = (; x = repeat(1:5, 4), y = rand(20), g = repeat(["a", "b", "c", "d"], inner = 5))
+    plt_small = data(df_small) * mapping(:x, :y, layout = :g) * visual(Lines)
+    fg_small = draw(plt_small; facet = (; size = fs_dynamic))
+    @test size(fg_small.grid) == (2, 2)
+    @test first(fg_small.grid).axis.height[] == 200
+
+    df_large = (; x = repeat(1:5, 9), y = rand(45), g = repeat(string.(1:9), inner = 5))
+    plt_large = data(df_large) * mapping(:x, :y, layout = :g) * visual(Lines)
+    fg_large = draw(plt_large; facet = (; size = fs_dynamic))
+    @test maximum(size(fg_large.grid)) >= 3
+    @test first(fg_large.grid).axis.height[] == 80
+end

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -67,14 +67,43 @@ end
     @test apply_palette(p, uv) == [p[1], p[2], p[3], p[1], p[2]]
 
     uv = 1:9
-    @test apply_palette(wrapped(), uv) == [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]
-    @test apply_palette(wrapped(by_col = true), uv) == [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2), (1, 3), (2, 3), (3, 3)]
+    # Default `wrapped()` is lazy: returns linear indices to be resolved later by `resolve_lazy_wrap`.
+    @test apply_palette(wrapped(), uv) == 1:9
+    @test apply_palette(wrapped(by_col = true), uv) == 1:9
     @test apply_palette(wrapped(cols = 4), uv) == [(1, 1), (1, 2), (1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4), (3, 1)]
     @test apply_palette(wrapped(cols = 4, by_col = true), uv) == [(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2), (1, 3), (2, 3), (3, 3)]
     @test apply_palette(wrapped(rows = 4), uv) == [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]
     @test apply_palette(wrapped(rows = 4, by_col = true), uv) == [(1, 1), (2, 1), (3, 1), (4, 1), (1, 2), (2, 2), (3, 2), (4, 2), (1, 3)]
     @test_throws_message "`cols` and `rows` can't both be fixed" apply_palette(wrapped(rows = 4, cols = 5), uv)
 end
+
+@testset "resolve_lazy_wrap" begin
+    using AlgebraOfGraphics: resolve_lazy_wrap
+
+    # Square axes preserve `ceil(sqrt(n))` behavior for common counts
+    @test resolve_lazy_wrap(1:9, 9, 1.0) == [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]
+    # n=16 → 4×4
+    @test maximum(first, resolve_lazy_wrap(1:16, 16, 1.0)) == 4
+    @test maximum(last, resolve_lazy_wrap(1:16, 16, 1.0)) == 4
+    # n=10 → 3×4
+    @test maximum(first, resolve_lazy_wrap(1:10, 10, 1.0)) == 3
+    @test maximum(last, resolve_lazy_wrap(1:10, 10, 1.0)) == 4
+
+    # Tall axes (aspect 0.5), n=10: more columns → 2×5
+    @test maximum(first, resolve_lazy_wrap(1:10, 10, 0.5)) == 2
+    @test maximum(last, resolve_lazy_wrap(1:10, 10, 0.5)) == 5
+
+    # 2 facets: wide axes stack vertically (2×1), tall axes side-by-side (1×2)
+    @test resolve_lazy_wrap(1:2, 2, 1.5) == [(1, 1), (2, 1)]
+    @test resolve_lazy_wrap(1:2, 2, 0.5) == [(1, 1), (1, 2)]
+
+    # Subset of indices: same wrapping based on `total`. Index 5 of 9 (3-col grid) → (2, 2).
+    @test resolve_lazy_wrap([5], 9, 1.0) == [(2, 2)]
+
+    # by_col swaps row/col output
+    @test resolve_lazy_wrap(1:4, 4, 1.0, true) == [(1, 1), (2, 1), (1, 2), (2, 2)]
+end
+
 
 @testset "datetimes" begin
     for d in [Date(2011, 9, 1), Date(2032, 5, 7), DateTime(2033, 9, 1, 3, 14, 16)]


### PR DESCRIPTION
## Motivation

When AoG figures use multiple facets, the resulting figure size is determined by Makie's default size. With many facets crammed into a fixed figure, axes get squeezed and labels overlap. Users have to manually set `axis = (; width = ..., height = ...)` and the figure auto-resizes.

But picking an axis size that works well requires considering:
- How many facets there are
- The aspect ratio of each axis (square scatter vs. wide time series)
- How the wrap layout will distribute them across rows/columns

Today these decisions are entangled — picking a column count via `wrapped(; cols = ...)` is independent of axis size, so wide axes in many columns produce overly wide figures.

This PR introduces a coordinated mechanism: a `FacetSize` "size policy" passed via `facet = (; size = ...)`, and a deferred wrap palette that uses the size's aspect ratio when computing the grid.

## Intended use

This is currently aimed at downstream packages that build plots on top of AoG (e.g., domain-specific plotting libraries) and want their plots to automatically choose sensible axis sizes for the data they encounter. Each recipe attaches a `FacetSize` policy that captures the right aspect (square scatter, wide time series, etc.) and a tier-based height function. End users can still override via `axis = (; width, height)`.

In the future this could become themeable, allowing end users to set default `FacetSize` policies globally rather than relying on whatever the recipe author baked in.

## Behavioral change to default wrap

The default `wrapped()` palette is now lazy: it returns linear indices, resolved to `(row, col)` later when the axis aspect is known. For square axes (the default when no `FacetSize` or width/height is given) this preserves the prior `ceil(sqrt(n))` behavior — `n = 9` still wraps to `3×3`, `n = 16` to `4×4`. For non-square aspects, the wrap chooses a column count that brings the bunched-together axis areas closest to a square shape.

The wrap layout has always been a visual heuristic (no "correct" answer); for non-square axes the new behavior may not always produce ideal layouts. Reference image tests covering layouts with non-square axis sizes will need regenerating.

## API

### `FacetSize(aspect, height_fn)`

- `aspect`: axis width / height — must be specified upfront (see implementation notes)
- `height_fn(n_rows, n_cols) -> Int`: returns the axis height after the grid layout is resolved

Width is derived as `height * aspect`.

### `facet = (; size = FacetSize(...))` in `draw`

```julia
draw(spec; facet = (; size = FacetSize(1.5, (nr, nc) -> max(nr, nc) <= 3 ? 200 : 100)))
```

### Aspect-aware default wrap

`wrapped()` (with default `cols`/`rows`) now defers grid resolution to draw time. When `FacetSize` is provided (or the user passes `axis = (; width, height)`), the resolved grid considers the axis aspect ratio. Custom `wrapped(; cols = N)` palettes still produce explicit `(row, col)` tuples and behave as before.

User-supplied `axis = (; width)` or `axis = (; height)` partial overrides combine with `FacetSize`: the missing dimension is derived from the aspect, and the layout still uses that aspect for wrapping.

## Examples

### Default (square) — 9 facets, lays out 3×3

```julia
using AlgebraOfGraphics, CairoMakie
df = (; x = repeat(1:5, 9), y = rand(45), g = repeat(string.(1:9), inner = 5))
plt = data(df) * mapping(:x, :y, layout = :g) * visual(Lines)
draw(plt; facet = (; size = FacetSize(1.0, (nr, nc) -> 100)))
```

<img width="418" height="472" alt="square 3x3" src="https://github.com/user-attachments/assets/d3220eca-4b91-4688-a06a-f858d6e5da73">

### Wide axes — 9 facets, lays out 5×2

```julia
draw(plt; facet = (; size = FacetSize(2.0, (nr, nc) -> 100)))
```

<img width="500" height="748" alt="wide 5x2" src="https://github.com/user-attachments/assets/f144549b-1a36-40c2-ac15-547684c74c5e">

### Tall axes — 9 facets, lays out 2×5

```julia
draw(plt; facet = (; size = FacetSize(0.5, (nr, nc) -> 200)))
```

<img width="654" height="533" alt="tall 2x5" src="https://github.com/user-attachments/assets/7f785be7-30e6-45a1-bc16-dce8fc4171d3">

### Tier-based sizing — same callback, different grid sizes

```julia
size_policy = FacetSize(1.0, (nr, nc) -> max(nr, nc) <= 2 ? 200 : 80)

# Small data: 4 facets in 2×2 → axes are 200×200
draw(small_plt; facet = (; size = size_policy))
```

<img width="500" height="533" alt="tier small 200" src="https://github.com/user-attachments/assets/00ed0311-c78e-4280-a10c-9aeb08f7132f">

```julia
# Larger data: 9 facets in 3×3 → axes shrink to 80×80
draw(large_plt; facet = (; size = size_policy))
```

<img width="358" height="412" alt="tier large 80" src="https://github.com/user-attachments/assets/a253ea91-c378-4dc4-938a-dc3973b53454">

### Two facets with wide axes stack vertically

```julia
df2 = (; x = repeat(1:10, 2), y = rand(20), g = repeat(["a", "b"], inner = 10))
plt2 = data(df2) * mapping(:x, :y, layout = :g) * visual(Lines)
draw(plt2; facet = (; size = FacetSize(1.5, (nr, nc) -> 200)))
```

<img width="382" height="533" alt="two wide stack" src="https://github.com/user-attachments/assets/9e16e587-9629-44e1-b8e9-5fbe26cd26fc">

### User axis overrides combine with `FacetSize` aspect

```julia
# User supplies width only; height derived from FacetSize aspect
draw(plt; facet = (; size = FacetSize(1.5, (nr, nc) -> 100)), axis = (; width = 300))
```

<img width="1018" height="772" alt="user override" src="https://github.com/user-attachments/assets/0947ecd2-e700-46e5-812b-a050350a71fe">

## Implementation notes

- **Why aspect is upfront, height is deferred**: the wrap layout decision (how to distribute N facets across rows/columns) is best made knowing the axis aspect — otherwise wide axes in many columns produce overly wide figures. But the resolved grid dimensions are an *output* of that decision, so the height function takes `(n_rows, n_cols)` and runs after wrapping. The aspect can't itself depend on the grid (that would be a chicken-and-egg loop), so it's specified upfront.
- The default `wrapped()` palette now returns linear indices. `compute_axes_grid` resolves them to `(row, col)` using `resolve_lazy_wrap` after categorical scales are fitted, with the effective aspect coming from `FacetSize` or user-supplied width+height (defaults to 1.0).
- The wrap algorithm picks `ncols ∈ {floor, ceil}(sqrt(n / aspect))` and chooses whichever makes `(cols × axis_w) / (rows × axis_h)` closest to 1. With `aspect = 1` this reduces to `ceil(sqrt(n))`.
- `compute_axes_grid` now accepts a `facet` kwarg (previously only `axis`).
- For pagination, `facet_size` is applied per-page in `_draw(ae::Matrix{AxisSpecEntries})`.

## Checks

- [x] `test/scales.jl`: `wrap palette` updated to assert the new lazy default; new `resolve_lazy_wrap` testset covers aspect-based grid choice (square preserves `ceil(sqrt(n))`, tall/wide adjust columns, partial indices, by_col).
- [x] `test/facet.jl`: new `facet_size` testset covers `FacetSize` integration — full default sizing, partial axis overrides (width-only, height-only), full overrides bypassing the policy, and dynamic tier-based sizing where the same `FacetSize` callback yields different sizes for different grids.
