### PR TITLE
feat(dodge): Route generic dodge_x/dodge_y to native dodge attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Plot types with a native `:dodge` attribute (`BarPlot`, `BoxPlot`, `Violin`, `CrossBar`) now also accept the generic `dodge_x`/`dodge_y` mapping, which is routed to `:dodge` when the aesthetic matches the plot's orientation. This makes it possible to share a single `dodge_x`/`dodge_y` mapping across companion layers (e.g., `Scatter` + `BarPlot`) without switching attribute names per layer. Specifying both `:dodge` and `:dodge_x`/`:dodge_y` on the same layer now errors [#747](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/747).
+
 ## v0.12.6 - 2026-03-30
 
 - Legend entries now hide elements from plot types that have no data for a given category (`hide_unused` defaults to `true`). This fixes misleading legends when layers with different plot types share a categorical scale but cover different subsets of categories (e.g., Scatter for "A" and Lines for "B" no longer both show a marker+line for every entry). The behavior can be controlled globally via `legend = (; hide_unused = false)` in `draw`, or per scale via `scales(Color = (; hide_unused_legend = false))`. Paginated plots also benefit, as each page's legend now only shows categories present on that page [#742](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/742).

--- a/docs/src/examples/scales/dodging.md
+++ b/docs/src/examples/scales/dodging.md
@@ -14,25 +14,38 @@ plt = data(df) * mapping(:x, :y, dodge = :group, color = :group) * visual(BarPlo
 draw(plt)
 ````
 
-Other plot types like errorbars do not have a `dodge` keyword, however you can dodge them using
-AlgebraOfGraphic's hardcoded `dodge_x` or `dodge_y` mappings.
-These will only shift the data away from the category centers but will not change
-other plot attributes (like dodging a barplot makes narrower bars).
-They are therefore mostly appropriate for "width-less" plot types like scatters or errorbars.
-
-If you combine errorbars with a barplot, AlgebraOfGraphics will apply the barplot's dodge width
-to the errorbars automatically so they match:
+You can also use the generic `dodge_x` or `dodge_y` mappings instead of `dodge`.
+On plot types that have a native `:dodge` attribute (`BarPlot`, `BoxPlot`, `Violin`, `CrossBar`),
+the generic form is automatically routed to the native one when the direction matches (e.g.
+`dodge_x` on a vertical barplot), so the bars are narrowed just as with `dodge`.
 
 ````@example dodging
-plt2 = data(df) * mapping(:x, :y, :err, dodge_x = :group) * visual(Errorbars)
-fg = draw(plt + plt2)
+plt = data(df) * mapping(:x, :y, dodge_x = :group, color = :group) * visual(BarPlot)
+draw(plt)
 ````
 
-If you only use "width-less" plot types, you will get an error if you don't set a dodge width manually.
+The advantage of `dodge_x`/`dodge_y` is that they work on any plot type, including "width-less" ones like
+`Scatter` or `Errorbars` that have no native `:dodge`. This makes it easy to share one mapping
+across layers that mix plot types. When combined with a plot type that has an inherent width,
+AlgebraOfGraphics applies that width to the width-less layers automatically so they match:
+
+````@example dodging
+shared = mapping(:x, :y, dodge_x = :group)
+plt = data(df) * (
+    shared * mapping(color = :group) * visual(BarPlot) +
+    shared * mapping(:err, group = :group) * visual(Errorbars)
+)
+draw(plt)
+````
+
+!!! note
+    Passing both `dodge` and `dodge_x`/`dodge_y` on the same layer is an error.
+
+If you only use width-less plot types, you will get an error if you don't set a dodge width manually.
 You can do so via the `scales` function:
 
 ````@example dodging
-df = (
+df2 = (
     x = repeat(1:10, inner = 2),
     y = cos.(range(0, 2pi, length = 20)),
     ylow = cos.(range(0, 2pi, length = 20)) .- 0.2,
@@ -41,7 +54,7 @@ df = (
 )
 
 f = Figure()
-plt3 = data(df) * (
+plt3 = data(df2) * (
     mapping(:x, :y, dodge_x = :dodge, color = :dodge) * visual(Scatter) +
     mapping(:x, :ylow, :yhigh, dodge_x = :dodge, color = :dodge) * visual(Rangebars)
 )
@@ -53,6 +66,3 @@ draw!(f[3, 1], plt3, scales(DodgeX = (; width = 1.0)); axis = (; title = "DodgeX
 
 f
 ````
-
-
-

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -736,6 +736,48 @@ end
 
 scale_setting_name(scale_id, aes::Type{<:Aesthetic}) = scale_id !== nothing ? scale_id : string(nameof(aes))[4:end]
 
+# If the user wrote the generic `dodge_x` / `dodge_y` on a plot that also has its own
+# `:dodge` attribute mapping to the matching `AesDodgeX` / `AesDodgeY`, rename the key
+# to `:dodge` so the plot's native dodge mechanism (e.g. BarPlot's width narrowing) is
+# used. Layers where the plot has no matching `:dodge` (e.g. Scatter), or whose `:dodge`
+# maps to the other axis, keep the generic key and use the manual-offset fallback path.
+function reroute_generic_dodge(p::ProcessedLayer)
+    (haskey(p.primary, :dodge_x) || haskey(p.primary, :dodge_y)) || return p
+
+    aes_map = aesthetic_mapping(p)
+    haskey(aes_map, :dodge) || return p
+    native_dodge_aes = aes_map[:dodge]::Type{<:Aesthetic}
+    native_dodge_aes in (AesDodgeX, AesDodgeY) || return p
+
+    has_native_dodge = haskey(p.primary, :dodge) || haskey(p.named, :dodge)
+
+    primary = copy(p.primary)
+    scale_mapping = copy(p.scale_mapping)
+    labels = copy(p.labels)
+
+    for (key, aes) in ((:dodge_x, AesDodgeX), (:dodge_y, AesDodgeY))
+        haskey(primary, key) || continue
+        aes === native_dodge_aes || continue
+
+        if has_native_dodge
+            error("Layer with plot type `$(Makie.plotsym(p.plottype))` received both `$key` and `dodge` mappings, which both target the $(aesname(aes)) aesthetic. Use only one.")
+        end
+
+        insert!(primary, :dodge, primary[key])
+        delete!(primary, key)
+        if haskey(scale_mapping, key)
+            insert!(scale_mapping, :dodge, scale_mapping[key])
+            delete!(scale_mapping, key)
+        end
+        if haskey(labels, key)
+            insert!(labels, :dodge, labels[key])
+            delete!(labels, key)
+        end
+    end
+
+    return ProcessedLayer(p; primary, scale_mapping, labels)
+end
+
 function compute_dodge(data, key::Symbol, dodgevalues, scale_mapping, categoricalscales, dodge_aes)
     scale_id = get(scale_mapping, key, nothing)
     scale = categoricalscales[dodge_aes][scale_id]

--- a/src/algebra/processing.jl
+++ b/src/algebra/processing.jl
@@ -186,7 +186,7 @@ function process(layer::Layer)
         map(transformed_processlayers.layers) do transformed_processlayer
             attributes = merge(mandatory_attributes(transformed_processlayer.plottype), transformed_processlayer.attributes)
             possibly_without_visual = ProcessedLayer(transformed_processlayer; attributes)
-            return set_missing_visual(possibly_without_visual)
+            return reroute_generic_dodge(set_missing_visual(possibly_without_visual))
         end
     )
 end

--- a/test/analyses.jl
+++ b/test/analyses.jl
@@ -636,3 +636,46 @@ end
     @test x̂[2] ≈ x̂2
     @test ŷ[2] ≈ ŷ2
 end
+
+@testset "generic dodge rerouting" begin
+    df = (
+        x = [1, 1, 2, 2],
+        y = [1.0, 2.0, 3.0, 4.0],
+        group = ["A", "B", "A", "B"],
+    )
+
+    # `dodge_x` on a vertical BarPlot (dodge aesthetic = AesDodgeX) is rerouted to `:dodge`
+    layer = data(df) * mapping(:x, :y, dodge_x = :group) * visual(AlgebraOfGraphics.BarPlot)
+    p = AlgebraOfGraphics.ProcessedLayer(layer)
+    @test haskey(p.primary, :dodge)
+    @test !haskey(p.primary, :dodge_x)
+
+    # `dodge_y` on a horizontal BarPlot (dodge aesthetic = AesDodgeY) is rerouted to `:dodge`
+    layer = data(df) * mapping(:y, :x, dodge_y = :group) * visual(AlgebraOfGraphics.BarPlot, direction = :x)
+    p = AlgebraOfGraphics.ProcessedLayer(layer)
+    @test haskey(p.primary, :dodge)
+    @test !haskey(p.primary, :dodge_y)
+
+    # `dodge_x` on a Scatter (no `:dodge` aesthetic) stays as `:dodge_x`
+    layer = data(df) * mapping(:x, :y, dodge_x = :group) * visual(Scatter)
+    p = AlgebraOfGraphics.ProcessedLayer(layer)
+    @test haskey(p.primary, :dodge_x)
+    @test !haskey(p.primary, :dodge)
+
+    # `dodge_y` on a vertical BarPlot (dodge aesthetic = AesDodgeX) is NOT rerouted (axis mismatch)
+    layer = data(df) * mapping(:x, :y, dodge_y = :group) * visual(AlgebraOfGraphics.BarPlot)
+    p = AlgebraOfGraphics.ProcessedLayer(layer)
+    @test haskey(p.primary, :dodge_y)
+    @test !haskey(p.primary, :dodge)
+
+    # `dodge_x` on a vertical BoxPlot is rerouted to `:dodge`
+    df_box = (x = [1, 1, 1, 2, 2, 2], y = [1.0, 2, 3, 4, 5, 6], group = ["A", "B", "A", "B", "A", "B"])
+    layer = data(df_box) * mapping(:x, :y, dodge_x = :group) * visual(AlgebraOfGraphics.BoxPlot)
+    p = AlgebraOfGraphics.ProcessedLayer(layer)
+    @test haskey(p.primary, :dodge)
+    @test !haskey(p.primary, :dodge_x)
+
+    # Both `:dodge` and `:dodge_x` on the same BarPlot is an error
+    layer = data(df) * mapping(:x, :y, dodge = :group, dodge_x = :group) * visual(AlgebraOfGraphics.BarPlot)
+    @test_throws "both `dodge_x` and `dodge`" AlgebraOfGraphics.ProcessedLayer(layer)
+end


### PR DESCRIPTION
## Summary

- Plot types with a native `:dodge` attribute (`BarPlot`, `BoxPlot`, `Violin`, `CrossBar`) now also accept the generic `dodge_x`/`dodge_y` mapping. When the aesthetic matches the plot's orientation (e.g. `dodge_x` on a vertical barplot), the key is rerouted to `:dodge` so the native mechanism (width narrowing, gap handling) is used.
- This makes it possible to share a single `dodge_x`/`dodge_y` mapping across companion layers (e.g. `Scatter` + `BarPlot`) without switching attribute names per layer.
- Specifying both `:dodge` and `dodge_x`/`dodge_y` on the same layer now errors with a clear message.
- Mismatched directions (e.g. `dodge_y` on a vertical barplot) are left alone and use the generic fallback path as before.

## Checks

- Verified unified `dodge_x` works correctly for BarPlot, BoxPlot, Violin, and CrossBar combined with Scatter
- Verified horizontal orientation with `dodge_y` works
- Verified error is raised when both `dodge` and `dodge_x` are specified
- Verified axis-mismatch case falls through to generic path
- All 4 existing dodge reference tests pass pixel-for-pixel
- All existing analyses.jl and algebra.jl tests pass
- Added 11 new unit tests covering all rerouting cases