### PR TITLE
Prepare v0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+## v0.12.8 - 2026-05-04
+
 - Plot types with a native `:dodge` attribute (`BarPlot`, `BoxPlot`, `Violin`, `CrossBar`) now also accept the generic `dodge_x`/`dodge_y` mapping, which is routed to `:dodge` when the aesthetic matches the plot's orientation. This makes it possible to share a single `dodge_x`/`dodge_y` mapping across companion layers (e.g., `Scatter` + `BarPlot`) without switching attribute names per layer. [#747](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/747).
-- Added aesthetics for `Stem` plots, including `color`, `marker`, and `markersize`. Legend displays like in a `Scatter` plot legend like style. 
+- Added support for `Stem` plots [#751](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/751).
 
 ## v0.12.7 - 2026-04-13
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.12.7"
+version = "0.12.8"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Releases v0.12.8 with the changes accumulated since v0.12.7:

- Generic `dodge_x`/`dodge_y` mapping routed to native `:dodge` (#747).
- `Stem` plot support (#751).

