### PR TITLE
ci: consolidate workflows into orchestrator with finalize gate

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+on:
+  workflow_call:
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - name: Setup docs environment
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg;
+          Pkg.instantiate()
+      - name: Run doctests
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Documenter: DocMeta, doctest
+          using AlgebraOfGraphics
+          DocMeta.setdocmeta!(AlgebraOfGraphics, :DocTestSetup, :(using AlgebraOfGraphics); recursive=true)
+          doctest(AlgebraOfGraphics)
+      - name: Build and deploy docs
+        run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/_formatting.yml
+++ b/.github/workflows/_formatting.yml
@@ -1,12 +1,7 @@
 name: Formatting
 on:
-  push:
-    branches:
-      - 'master'
-      - 'release-'
-    tags:
-      - '*'
-  pull_request:
+  workflow_call:
+
 jobs:
   runic:
     name: Runic formatting

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,33 @@
+name: Test
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'min'
+          - 'lts'
+          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,57 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  formatting:
+    uses: ./.github/workflows/_formatting.yml
+
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - 'min'
-          - 'lts'
-          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/_test.yml
+    secrets: inherit
+
   docs:
-    name: Documentation
+    uses: ./.github/workflows/_docs.yml
+    secrets: inherit
+
+  finalize:
+    name: CI result
     runs-on: ubuntu-latest
+    if: always()
+    needs: [formatting, test, docs]
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - name: Setup docs environment
-        shell: julia --color=yes --project=docs {0}
-        run: |
-          using Pkg;
-          Pkg.instantiate()
-      - name: Run doctests
-        shell: julia --color=yes --project=docs {0}
-        run: |
-          using Documenter: DocMeta, doctest
-          using AlgebraOfGraphics
-          DocMeta.setdocmeta!(AlgebraOfGraphics, :DocTestSetup, :(using AlgebraOfGraphics); recursive=true)
-          doctest(AlgebraOfGraphics)
-      - name: Build and deploy docs
-        run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - run: |
+          results='${{ toJSON(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -qE '"(failure|cancelled)"'; then
+            echo "Some required jobs failed or were cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- `ci.yml` becomes a thin orchestrator that calls reusable workflow files (`_test.yml`, `_docs.yml`, `_formatting.yml`) via `workflow_call`
- A `finalize` job named **CI result** aggregates the results of all called workflows, so branch protection can require just that one status check (enabling auto-merge)
- Folds the standalone `Formatting.yml` into the orchestrator group
- `enforce-changelog.yml` stays separate because its `labeled`/`unlabeled` `pull_request` event types would re-trigger the whole CI graph if folded in

After merging, set **CI result** as the only required status check (alongside *Enforce changelog*) in branch protection.

Mirrors the structure introduced in MakieOrg/Makie.jl#5598.

## Checks

- YAML files parse cleanly
- Job definitions match the previous workflows (test matrix, docs build/deploy, runic formatting) byte-for-byte modulo the `workflow_call` trigger
- `secrets: inherit` is set on `test` (CODECOV_TOKEN) and `docs` (DOCUMENTER_KEY) calls
- The `finalize` step uses `if: always()` so it runs even when an upstream job fails, and exits non-zero on `failure`/`cancelled`