### PR TITLE
ci(tagbot): grant contents/issues write permissions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,6 +8,10 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: read
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
Fixes #755.

The TagBot workflow had no `permissions` block, so the default `GITHUB_TOKEN` lacked `contents: write` and could not push the v0.12.8 tag or create the GitHub Release. This adds a minimal permissions block matching what TagBot needs.

## Checks

- [ ] TagBot run on the next release succeeds without manual intervention.
