### PR TITLE
Prepare v0.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.9 - 2026-05-19
+
 - Analyses (`linear`, `smooth`, `density`, `histogram`, `expectation`, `frequency`, `contours`, `filled_contours`) now accept `Unitful.Quantity` and `DynamicQuantities.Quantity` data [#758](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/758).
 - Analyses (`density`, `histogram`, `linear`, `smooth`, `frequency`, `expectation`) now drop rows where any numeric input is `missing` or `NaN`, instead of erroring or producing garbage. `Inf`/`-Inf` throw errors. [#757](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/757).
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Releases v0.12.9 with the changes accumulated since v0.12.8:

- Analyses accept `Unitful` / `DynamicQuantities` quantities (#758).
- Analyses drop missing/NaN rows and error on Inf (#757).