### PR TITLE
Prepare v0.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.10 - 2026-06-02
+
 - `ABLines` now aligns `Unitful` and `DynamicQuantities` units, with the intercept matching the y unit and the slope the y/x unit, and errors on incompatible units [#761](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/761).
 
 ## v0.12.9 - 2026-05-19

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.12.9"
+version = "0.12.10"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Releases v0.12.10 with the changes accumulated since v0.12.9:

- `ABLines` now aligns `Unitful` / `DynamicQuantities` units (intercept matches the y unit, slope the y/x unit), and errors on incompatible units (#761).
