### PR TITLE
fix(ablines): Accept dimensionless slope when AesX and AesY share a unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.12.11 - 2026-06-02
+
+- Fixed `ABLines` unit alignment rejecting a dimensionless slope when `AesX` and `AesY` carry the same unit [#763](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/763).
+
 ## v0.12.10 - 2026-06-02
 
 - `ABLines` now aligns `Unitful` and `DynamicQuantities` units, with the intercept matching the y unit and the slope the y/x unit, and errors on incompatible units [#761](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/761).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.12.10"
+version = "0.12.11"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
+++ b/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
@@ -83,4 +83,9 @@ function AlgebraOfGraphics.dimensionally_compatible(q1::DynamicQuantities.Quanti
     end
 end
 
+# a unit-free aesthetic (`nothing`) is a pure number, so it matches a dimensionless quantity
+# (e.g. an ABLines slope when AesX and AesY share the same unit).
+AlgebraOfGraphics.dimensionally_compatible(q::DQ.Quantity, ::Nothing) = iszero(DQ.dimension(DQ.uexpand(q)))
+AlgebraOfGraphics.dimensionally_compatible(::Nothing, q::DQ.Quantity) = iszero(DQ.dimension(DQ.uexpand(q)))
+
 end

--- a/ext/AlgebraOfGraphicsUnitfulExt.jl
+++ b/ext/AlgebraOfGraphicsUnitfulExt.jl
@@ -40,4 +40,9 @@ function AlgebraOfGraphics.dimensionally_compatible(u1::Unitful.FreeUnits, u2::U
     return Unitful.dimension(u1) == Unitful.dimension(u2)
 end
 
+# a unit-free aesthetic (`nothing`) is a pure number, so it matches a dimensionless unit
+# (e.g. an ABLines slope when AesX and AesY share the same unit collapses to a plain number).
+AlgebraOfGraphics.dimensionally_compatible(u::Unitful.FreeUnits, ::Nothing) = Unitful.dimension(u) == Unitful.NoDims
+AlgebraOfGraphics.dimensionally_compatible(::Nothing, u::Unitful.FreeUnits) = Unitful.dimension(u) == Unitful.NoDims
+
 end

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -291,6 +291,11 @@ if VERSION >= v"1.9"
         @test !AlgebraOfGraphics.dimensionally_compatible(D.u"kg", nothing)
         @test !AlgebraOfGraphics.dimensionally_compatible(nothing, D.u"kg")
 
+        @test AlgebraOfGraphics.dimensionally_compatible(U.u"ng/mL" / U.u"ng/mL", nothing)
+        @test AlgebraOfGraphics.dimensionally_compatible(nothing, U.u"ng/mL" / U.u"ng/mL")
+        @test AlgebraOfGraphics.dimensionally_compatible(D.us"ng/mL" / D.us"ng/mL", nothing)
+        @test AlgebraOfGraphics.dimensionally_compatible(nothing, D.us"ng/mL" / D.us"ng/mL")
+
         @test !AlgebraOfGraphics.dimensionally_compatible(U.u"kg", U.u"m")
         @test AlgebraOfGraphics.dimensionally_compatible(U.u"kg", U.u"g")
 
@@ -330,6 +335,13 @@ if VERSION >= v"1.9"
 
             @test_throws_message "incompatible dimensions for AesY and AesABIntercept" draw(base + mapping([1.0] .* meter, [0.0] .* s_per_m) * visual(ABLines))
             @test_throws_message "ABLines slope whose unit is not dimensionally compatible" draw(base + mapping([0.0] .* s, [1.0] .* s) * visual(ABLines))
+
+            # AesX and AesY share a unit, so the slope unit(AesY)/unit(AesX) is dimensionless
+            # and collapses to a plain number with no unit; that must still align as the identity line.
+            base_same = data((; x = (1.0:5) .* s, y = (2.0:2:10) .* s)) * mapping(:x, :y) * visual(Scatter)
+            @test ablines_pos(base_same + mapping([0.0] .* s, [1.0]) * visual(ABLines)) == (0.0, 1.0)
+            @test ablines_pos(base_same + mapping([0.0] .* s, [2.0] .* (s / s)) * visual(ABLines)) == (0.0, 2.0)
+            @test_throws_message "ABLines slope whose unit is not dimensionally compatible" draw(base_same + mapping([0.0] .* s, [1.0] .* s) * visual(ABLines))
         end
     end
 


### PR DESCRIPTION
When `AesX` and `AesY` share a unit, the slope `unit(AesY)/unit(AesX)` is dimensionless and Unitful collapses it to a plain number, which alignment then rejected against the expected unit. This broke identity lines where both axes use the same unit (e.g. predicted-vs-observed). A unit-free slope is now accepted as dimensionless.
