### PR TITLE
fix(scales): Match palette and categories against presorted/nonnumeric data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Palette pairs and `categories` passed via `scales` now match `presorted`/`nonnumeric`-wrapped data without needing to re-wrap the keys [#766](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/766).
+
 ## v0.12.11 - 2026-06-02
 
 - Fixed `ABLines` unit alignment rejecting a dimensionless slope when `AesX` and `AesY` carry the same unit [#763](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/763).

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -247,6 +247,15 @@ Base.isequal(p::Presorted, p2::Presorted) = isequal(p.x, p2.x)
 Base.:(==)(p::Presorted, p2::Presorted) = p.x == p2.x
 Base.hash(p::Presorted) = hash(p.x)
 
+# `presorted` and `nonnumeric` wrap a value to change how it sorts or which scale it gets,
+# without changing its identity. `unwrap` recovers the underlying value (recursively, in case
+# of nesting) so that palette pairs and `categories` passed via `scales` can be matched against
+# wrapped data values without the user having to re-wrap them.
+unwrap(x) = x
+unwrap(p::Presorted) = unwrap(p.x)
+unwrap(n::NonNumeric) = unwrap(n.x)
+unwrap_isequal(a, b) = isequal(unwrap(a), unwrap(b))
+
 struct FromContinuous{T}
     continuous::T
     relative::Bool

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -85,7 +85,7 @@ function Cycler(p)
 end
 
 function (c::Cycler)(u)
-    i = findfirst(isequal(u), c.keys)
+    i = findfirst(k -> unwrap_isequal(k, u), c.keys)
     return if isnothing(i)
         l = length(c.defaults)
         l == 0 && throw(ArgumentError("Key $(repr(u)) not found and no default values are present"))
@@ -378,16 +378,17 @@ function datavalues(c::CategoricalScale)
         else
             catvalues = map(category_value, c.props.categories)
         end
-        u = try
-            union(catvalues, c.data)
-        catch e
-            throw(ArgumentError("Custom categories were given but unioning them with the categories determined from the data failed."))
-        end
-        if u != catvalues
-            extraneous = setdiff(c.data, catvalues)
+        extraneous = filter(d -> !any(cv -> unwrap_isequal(cv, d), catvalues), c.data)
+        if !isempty(extraneous)
             throw(ArgumentError("Custom categories were given but there were more categories in the data, which is not allowed. The additional categories were $extraneous"))
         end
-        u
+        # Keep the actual (possibly wrapped) data value where a category matches it, so that the
+        # per-row lookup via `indexin` in `numerical_rescale` still matches; fall back to the
+        # given value for categories that don't appear in the data (reserved legend slots).
+        map(catvalues) do cv
+            i = findfirst(d -> unwrap_isequal(cv, d), c.data)
+            i === nothing ? cv : c.data[i]
+        end
     end
 end
 plotvalues(c::CategoricalScale) = c.plot

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -84,6 +84,21 @@ end
     ]
 end
 
+@testset "unwrap" begin
+    unwrap = AlgebraOfGraphics.unwrap
+    unwrap_isequal = AlgebraOfGraphics.unwrap_isequal
+
+    @test unwrap("a") == "a"
+    @test unwrap(Presorted("a", 0x0003)) == "a"
+    @test unwrap(nonnumeric(1)) == 1
+    @test unwrap(Presorted(nonnumeric(1), 0x0003)) == 1
+
+    @test unwrap_isequal(Presorted("a", 0x0003), "a")
+    @test unwrap_isequal("a", Presorted("a", 0x0003))
+    @test unwrap_isequal(nonnumeric(1), Presorted(1, 0x0001))
+    @test !unwrap_isequal(Presorted("a", 0x0003), "b")
+end
+
 @testset "_kwdict errors" begin
     spec = mapping()
     @test_throws_message "Can't convert value passed via the keyword `axis`" draw(spec, axis = (key = :value))

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -33,6 +33,33 @@
     @test scale.plot == 1:2
 end
 
+@testset "wrapped categorical lookup" begin
+    df = (; Pet = ["Fish", "Dog", "Cat", "Bird"], Ranking = 1:4)
+    l = data(df) * mapping(:Pet => presorted, :Ranking, color = :Pet => presorted)
+    pl = ProcessedLayer(l)
+    aesmapping = AlgebraOfGraphics.aesthetic_mapping(pl)
+
+    palette = ["Cat" => :green, "Dog" => :red, "Fish" => :blue, "Bird" => :yellow]
+    sp = AlgebraOfGraphics.compute_scale_properties([pl], AlgebraOfGraphics.scales(Color = (; palette)))
+    scale = map(fitscale, categoricalscales(pl, sp, aesmapping))[:color]
+    @test datavalues(scale) == Presorted.(["Fish", "Dog", "Cat", "Bird"])
+    @test scale.plot == [:blue, :red, :green, :yellow]
+
+    sp = AlgebraOfGraphics.compute_scale_properties([pl], AlgebraOfGraphics.scales(Color = (; categories = ["Bird", "Cat", "Dog", "Fish"])))
+    scale = map(fitscale, categoricalscales(pl, sp, aesmapping))[:color]
+    dv = datavalues(scale)
+    @test dv == Presorted.(["Bird", "Cat", "Dog", "Fish"])
+    @test eltype(dv) <: Presorted
+    @test indexin(Presorted.(["Fish", "Dog", "Cat", "Bird"]), dv) == [4, 3, 2, 1]
+
+    sp = AlgebraOfGraphics.compute_scale_properties([pl], AlgebraOfGraphics.scales(Color = (; categories = ["Cat", "Dog"])))
+    @test_throws_message "there were more categories in the data" map(fitscale, categoricalscales(pl, sp, aesmapping))
+
+    spec = l * visual(BarPlot)
+    @test draw(spec, AlgebraOfGraphics.scales(Color = (; palette))) isa AlgebraOfGraphics.FigureGrid
+    @test draw(spec, AlgebraOfGraphics.scales(Color = (; categories = ["Bird", "Cat", "Dog", "Fish"]))) isa AlgebraOfGraphics.FigureGrid
+end
+
 @testset "extrema" begin
     v = [1, missing, 2, NaN]
     @test extrema_finite(v) == (1, 2)


### PR DESCRIPTION
When you wrap a column with `presorted` (or `nonnumeric`) and then want to assign colors via a palette, you have to specify the palette keys as plain values like `"Cat" => :green`. But the data values are `Presorted("Cat")`, so the palette lookup never matched and you'd get an error like

```
ERROR: ArgumentError: Key Fish not found and no default values are present
```

The same applied to `categories`, where listing the plain values failed against the wrapped data. This was the issue discussed in #720; rather than overloading `isequal` on the wrapper types (which is a fundamental operation better left alone), this adds a recursive `unwrap` and compares both the given and the existing value unwrapped before checking equality.

So this now works as you'd expect:

```julia
df = (; Pet = ["Fish", "Dog", "Cat", "Bird"], Ranking = 1:4)
spec = data(df) *
    mapping(:Pet => presorted, :Ranking, color = :Pet => presorted) *
    visual(BarPlot)

palette = ["Cat" => :green, "Dog" => :red, "Fish" => :blue, "Bird" => :yellow]
draw(spec, scales(Color = (; palette)))
```

<img width="400" height="400" alt="bar plot with presorted pets colored via a plain-string palette" src="https://github.com/user-attachments/assets/408b14d7-beb2-4d37-aa00-4d16652ad8d1">
