### PR TITLE
ci(reftests): Post a commit status linking to the PixelMatch report

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,6 +6,9 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      statuses: write
     strategy:
       fail-fast: false
       matrix:
@@ -33,12 +36,27 @@ jobs:
           f=test/reference_tests/pixelmatch-report.html
           [ -f "$f" ] && mv "$f" "test/reference_tests/pixelmatch-report-${{ matrix.version }}.html" || true
       - name: Upload PixelMatch report
+        id: upload-report
         if: failure() && steps.runtests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           path: test/reference_tests/pixelmatch-report-${{ matrix.version }}.html
           archive: false
           if-no-files-found: ignore
+      - name: Post failing status linking to the report
+        if: failure() && steps.runtests.outcome == 'failure' && steps.upload-report.outputs.artifact-url != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request?.head?.sha ?? context.sha,
+              state: 'failure',
+              context: `PixelMatch report (Julia ${{ matrix.version }})`,
+              target_url: '${{ steps.upload-report.outputs.artifact-url }}',
+              description: 'Reference image failures, click Details for the HTML report',
+            })
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
 
   test:
     uses: ./.github/workflows/_test.yml
+    permissions:
+      contents: read
+      statuses: write
     secrets: inherit
 
   docs:


### PR DESCRIPTION
When reference tests fail, the run already uploads a self-contained HTML PixelMatch report as an artifact, but you have to dig through the run's artifacts to find it. This posts a failing commit status (one per Julia version) whose Details link points straight at the report.

Uses `actions/github-script@v9` and needs `statuses: write`, granted on the `test` job and threaded through the `ci.yml` caller.
