### PR TITLE
Prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0 - 2026-06-25
+
 - Analyses (`linear`, `smooth`, `density`, `histogram`, `expectation`, `filled_contours`) now fit in transformed space and back-transform their output when the relevant aesthetic carries a `scale` function set via `scales` (e.g. `scales(Y = (; scale = log10))`), so a fit on log-scaled data is computed in log space. This is distinct from `axis = (; yscale = ...)`, which only transforms the display [#773](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/773).
 - `histogram` now accepts a `direction` (`:x` or `:y`) keyword for 1D histograms, which sets the bar orientation and the aesthetic (and thus scale space) the bins are computed in [#773](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/773).
 - `smooth` with the default `degree = 2` no longer collapses on `Date` (and other large-magnitude) x axes [#774](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/774).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.12.13"
+version = "0.13.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Minor release. Highlights:

- Analyses (`linear`, `smooth`, `density`, `histogram`, `expectation`, `filled_contours`) now fit in transformed space and back-transform when the aesthetic carries a `scale` function via `scales` (e.g. `scales(Y = (; scale = log10))`) [#773](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/773).
- `histogram` now accepts a `direction` (`:x` or `:y`) keyword for 1D histograms [#773](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/773).
- `smooth` with the default `degree = 2` no longer collapses on `Date` (and other large-magnitude) x axes [#774](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/774).

The transformed-space analyses feature warrants the minor (`0.12.13` → `0.13.0`) bump.
