### PR TITLE
fix(units): Handle missing values in Unitful and DynamicQuantities columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.13.1 - 2026-07-09
+
+- Unitful and DynamicQuantities columns containing `missing` values no longer error when drawn [#777](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/777).
+
 ## v0.13.0 - 2026-06-25
 
 - Analyses (`linear`, `smooth`, `density`, `histogram`, `expectation`, `filled_contours`) now fit in transformed space and back-transform their output when the relevant aesthetic carries a `scale` function set via `scales` (e.g. `scales(Y = (; scale = log10))`), so a fit on log-scaled data is computed in log space. This is distinct from `axis = (; yscale = ...)`, which only transforms the display [#773](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/773).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
+++ b/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
@@ -4,7 +4,9 @@ import AlgebraOfGraphics
 import DynamicQuantities
 const DQ = DynamicQuantities
 
-AlgebraOfGraphics.extrema_finite(v::AbstractVector{<:DQ.Quantity}) = extrema(Iterators.filter(isfinite, skipmissing(v)))
+const MaybeMissingQuantities = AbstractVector{<:Union{Missing, DQ.Quantity}}
+
+AlgebraOfGraphics.extrema_finite(v::MaybeMissingQuantities) = extrema(Iterators.filter(isfinite, skipmissing(v)))
 
 struct DimensionMismatch{X1, X2} <: Exception
     x1::X1
@@ -19,23 +21,23 @@ function dimensionless(x, u::DQ.Quantity{<:Any, <:DQ.Dimensions})
     return DQ.ustrip(xexp)
 end
 
-function AlgebraOfGraphics.strip_units(scale, data::AbstractVector{<:DQ.Quantity})
+function AlgebraOfGraphics.strip_units(scale, data::MaybeMissingQuantities)
     u = AlgebraOfGraphics.getunit(scale)
     scale_unitless = AlgebraOfGraphics.ContinuousScale(dimensionless.(scale.extrema, u), scale.label, scale.force, scale.props)
-    data_unitless = dimensionless.(data, u)
+    data_unitless = AlgebraOfGraphics.map_nonmissing(x -> dimensionless(x, u), data)
     return scale_unitless, data_unitless
 end
 
-AlgebraOfGraphics.to_unitless_numerical(x::AbstractVector{<:DQ.Quantity}) = DQ.ustrip.(x)
+AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(DQ.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::DQ.Quantity) = DQ.ustrip(x)
 
 # `oneunit` on the DQ.Quantity element type fails because the dimensions are stored at runtime,
 # not in the type, so we have to inspect values. Trusting `first(x)` alone would silently accept
 # vectors with mixed units; instead verify every element shares the same `oneunit` and error
-# otherwise. Empty vectors still error here because there's no element to read the unit from,
+# otherwise. Empty or all-missing vectors still error here because there's no element to read the unit from,
 # which matches the documented limitation that empty unit-bearing groups cannot be analysed.
-function only_oneunit(x::AbstractVector{<:DQ.Quantity})
-    first_q, rest = Iterators.peel(x)
+function only_oneunit(x::MaybeMissingQuantities)
+    first_q, rest = Iterators.peel(skipmissing(x))
     u = oneunit(first_q)
     for q in rest
         oneunit(q) == u || error("Encountered multiple different units in a DynamicQuantities vector: $u and $(oneunit(q))")
@@ -43,7 +45,7 @@ function only_oneunit(x::AbstractVector{<:DQ.Quantity})
     return u
 end
 
-AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::AbstractVector{<:DQ.Quantity}) =
+AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::MaybeMissingQuantities) =
     x̂ .* only_oneunit(x)
 
 AlgebraOfGraphics.is_unit(::DynamicQuantities.Quantity) = true # there seems to be no FreeUnits equivalent in DQ
@@ -52,7 +54,7 @@ function AlgebraOfGraphics.unit_string(u::DQ.Quantity)
     return string(DQ.dimension(u))
 end
 
-AlgebraOfGraphics.getunit(v::AbstractVector{<:DQ.Quantity}) = only_oneunit(v)
+AlgebraOfGraphics.getunit(v::MaybeMissingQuantities) = only_oneunit(v)
 
 function AlgebraOfGraphics.getunit(scale::AlgebraOfGraphics.ContinuousScale{T}) where {T <: DynamicQuantities.Quantity}
     o1, o2 = oneunit.(scale.extrema)

--- a/ext/AlgebraOfGraphicsUnitfulExt.jl
+++ b/ext/AlgebraOfGraphicsUnitfulExt.jl
@@ -3,23 +3,25 @@ module AlgebraOfGraphicsUnitfulExt
 import AlgebraOfGraphics
 import Unitful
 
-function AlgebraOfGraphics.strip_units(scale, data::AbstractVector{<:Unitful.Quantity})
+const MaybeMissingQuantities = AbstractVector{<:Union{Missing, Unitful.Quantity}}
+
+function AlgebraOfGraphics.strip_units(scale, data::MaybeMissingQuantities)
     u = AlgebraOfGraphics.getunit(scale)
     scale_unitless = AlgebraOfGraphics.ContinuousScale(Unitful.ustrip.(u, scale.extrema), scale.label, scale.force, scale.props)
-    data_unitless = Unitful.ustrip.(u, data)
+    data_unitless = AlgebraOfGraphics.map_nonmissing(x -> Unitful.ustrip(u, x), data)
     return scale_unitless, data_unitless
 end
 
-AlgebraOfGraphics.to_unitless_numerical(x::AbstractVector{<:Unitful.Quantity}) = Unitful.ustrip.(x)
+AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(Unitful.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::Unitful.Quantity) = Unitful.ustrip(x)
-AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::AbstractVector{<:Unitful.Quantity}) =
-    x̂ .* Unitful.unit(eltype(x))
+AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::MaybeMissingQuantities) =
+    x̂ .* Unitful.unit(nonmissingtype(eltype(x)))
 
 function AlgebraOfGraphics.unit_string(u::Unitful.FreeUnits)
     return string(u)
 end
 
-AlgebraOfGraphics.getunit(v::AbstractVector{<:Unitful.Quantity}) = Unitful.unit(eltype(v))
+AlgebraOfGraphics.getunit(v::MaybeMissingQuantities) = Unitful.unit(nonmissingtype(eltype(v)))
 
 AlgebraOfGraphics.is_unit(::Unitful.FreeUnits) = true
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -514,6 +514,8 @@ getunit(::AbstractVector) = nothing
 
 function unit_string end
 
+map_nonmissing(f, v::AbstractVector) = map(x -> ismissing(x) ? missing : f(x), v)
+
 dimensionally_compatible(::Nothing, ::Nothing) = true
 dimensionally_compatible(_, _) = false
 

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -337,6 +337,29 @@ if VERSION >= v"1.9"
         @test_throws_message "incompatible dimensions for AesY and AesDeltaY scales" draw(data((; id = 1:3, value = [1, 2, 3] .* U.u"m", err = [0.5, 0.6, 0.7] .* U.u"kg")) * mapping(:id, :value, :err) * visual(Errorbars))
     end
 
+    @testset "Units with missing values" begin
+        for (unit, override, factor) in [
+                (U.u"mg/L", U.u"g/L", 0.001),
+                (D.us"mg/L", D.us"g/L", 0.001),
+            ]
+            df = (; x = [1, 2, 3, 4], y = [1.0, missing, 3.0, 4.0] .* Ref(unit))
+            spec = data(df) * mapping(:x, :y) * visual(ScatterLines)
+
+            fg = draw(spec)
+            yscale = fg.grid[].continuousscales[AlgebraOfGraphics.AesY][nothing]
+            @test AlgebraOfGraphics.getunit(yscale) == unit
+            @test yscale.extrema == (1.0 * unit, 4.0 * unit)
+            e = only(fg.grid[1].entries)
+            @test isequal(e.positional[2], [1.0, missing, 3.0, 4.0])
+
+            fg2 = draw(spec, scales(Y = (; unit = override)))
+            yscale2 = fg2.grid[].continuousscales[AlgebraOfGraphics.AesY][nothing]
+            @test AlgebraOfGraphics.getunit(yscale2) == override
+            e2 = only(fg2.grid[1].entries)
+            @test isequal(e2.positional[2], factor .* [1.0, missing, 3.0, 4.0])
+        end
+    end
+
     @testset "ABLines units" begin
         function ablines_pos(spec)
             fg = draw(spec)


### PR DESCRIPTION
The unit extension methods dispatched only on `AbstractVector{<:Quantity}` and not on the `Union{Missing, Quantity}` eltypes you get with `missing`s in a column, which broke drawing such data. Missings are now preserved through unit stripping and render as gaps like in the unitless case:

```julia
df = (; x = [1, 2, 3, 4], y = [1.0, missing, 3.0, 4.0] .* Ref(us"mg/L"))
draw(data(df) * mapping(:x, :y) * visual(ScatterLines))
```

<img width="600" height="450" alt="scatterlines with a gap at the missing value" src="https://github.com/user-attachments/assets/7d951163-4041-403f-83e1-b256adf1959d">

Also bumps the version to v0.13.1.
