### PR TITLE
Support temporal columns on continuous color and size scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#778](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/778).
+
 ## v0.13.1 - 2026-07-09
 
 - Unitful and DynamicQuantities columns containing `missing` values no longer error when drawn [#777](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/777).

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -729,6 +729,7 @@ function full_rescale(data, key, aes_mapping, scale_mapping, categoricalscales, 
     scale === nothing && return data # verbatim data
     if scale isa ContinuousScale
         scale, data = strip_units(scale, data)
+        scale = strip_temporal(scale)
     end
     return full_rescale(data, aes, scale)
 end
@@ -742,7 +743,7 @@ full_rescale(data, aes, scale::CategoricalScale) = rescale(data, scale)
 function nonsingular_colorrange(scale::ContinuousScale)
     props = scale.props.aesprops::AesColorContinuousProps
     cr = @something(props.colorrange, scale.extrema)
-    return nonsingular_limits(cr)
+    return nonsingular_limits(map(strip_temporal, cr))
 end
 
 # expand singular limits to (0, v) or (v, 0) if singular value v is nonzero

--- a/src/guides/colorbar.jl
+++ b/src/guides/colorbar.jl
@@ -57,6 +57,9 @@ end
 
 function continuous_colorbar(colorscale::ContinuousScale)
     label = getlabel(colorscale)
+    # temporal extrema get date-formatted colorbar ticks, other types return `automatic`
+    cbar_ticks = ticks(colorscale.extrema)
+    colorscale = strip_temporal(colorscale)
     limits = nonsingular_colorrange(colorscale)
     is_highclipped = limits[2] < colorscale.extrema[2]
     is_lowclipped = limits[1] > colorscale.extrema[1]
@@ -78,6 +81,7 @@ function continuous_colorbar(colorscale::ContinuousScale)
         lowclip,
         highclip,
         scale,
+        ticks = cbar_ticks,
     )
 end
 

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -380,8 +380,10 @@ end
 datavalues_plotvalues_datalabels(aes, scale::CategoricalScale) = datavalues(scale), plotvalues(scale), datalabels(scale)
 function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::ContinuousScale)
     props = scale.props.aesprops::AesMarkerSizeContinuousProps
+    tickfinder = temporal_tickfinder(scale, props.ticks)
+    scale = strip_temporal(scale)
     _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
-    tickvalues, ticklabels = Makie.get_ticks(props.ticks, identity, props.tickformat, s_extrema...)
+    tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]
         error("Range of tick values for MarkerSize scale $(t_extrema) exceeds data range $(s_extrema)")
@@ -391,8 +393,10 @@ function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::Conti
 end
 function datavalues_plotvalues_datalabels(aes::Type{AesLineWidth}, scale::ContinuousScale)
     props = scale.props.aesprops::AesLineWidthContinuousProps
+    tickfinder = temporal_tickfinder(scale, props.ticks)
+    scale = strip_temporal(scale)
     _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
-    tickvalues, ticklabels = Makie.get_ticks(props.ticks, identity, props.tickformat, s_extrema...)
+    tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]
         error("Range of tick values for LineWidth scale $(t_extrema) exceeds data range $(s_extrema)")

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -579,6 +579,26 @@ datetime2float(x::Union{DateTime, Date}) = datetime2float(DateTime(x) - DateTime
 datetime2float(x::Time) = datetime2float(x - Time(0))
 datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 
+# Temporal data is converted to floats early (`contextfree_rescale`), but scale extrema
+# keep their temporal type so axis ticks can be formatted as dates. Aesthetics that combine
+# data with extrema numerically (color, markersize, linewidth) need the extrema as floats,
+# so scales are passed through `strip_temporal` before rescaling.
+strip_temporal(x::Union{TimeType, Period}) = datetime2float(x)
+strip_temporal(x) = x
+
+strip_temporal(scale::ContinuousScale) = scale
+function strip_temporal(scale::ContinuousScale{<:Union{TimeType, Period}})
+    return ContinuousScale(map(datetime2float, scale.extrema), scale.label, scale.force, scale.props)
+end
+
+# The markersize/linewidth legends compute tick labels from the scale extrema. For temporal
+# extrema, the default numeric tick finder would label the raw millisecond floats, so swap
+# it for date-formatted ticks; user-supplied ticks are kept as-is.
+temporal_tickfinder(::ContinuousScale, ticks) = ticks
+function temporal_tickfinder(::ContinuousScale{T}, ticks) where {T <: TimeType}
+    return ticks === _default_markersize_ticks ? DateTicksWrapper{T}(automatic) : ticks
+end
+
 """
     datetimeticks(datetimes::AbstractVector{<:TimeType}, labels::AbstractVector{<:AbstractString})
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -583,6 +583,11 @@ datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 # keep their temporal type so axis ticks can be formatted as dates. Aesthetics that combine
 # data with extrema numerically (color, markersize, linewidth) need the extrema as floats,
 # so scales are passed through `strip_temporal` before rescaling.
+# This is the temporal analogue of `strip_units`; they differ because units need a target
+# unit (`props.unit`) and data conversion, while temporal data is float already. Should a
+# third non-float continuous family ever arise, consider unifying the pattern shared by
+# the colorbar and markersize/linewidth legends — "derive a tick finder from the typed
+# extrema, then strip the scale to float space" — into a single seam.
 strip_temporal(x::Union{TimeType, Period}) = datetime2float(x)
 strip_temporal(x) = x
 

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -171,6 +171,62 @@ end
 
 end
 
+@testset "temporal continuous color scales" begin
+    df = (; x = 1:4, y = [1, 3, 2, 4], t = DateTime(2024, 1, 1) .+ Day.(0:3))
+    cmap = Makie.to_colormap(AlgebraOfGraphics.default_colormap())
+
+    fg = draw(data(df) * mapping(:x, :y, color = :t))
+    colors = only(fg.grid[1].entries).named[:color]
+    @test colors[1] == cmap[1]
+    @test colors[end] == cmap[end]
+    @test length(unique(colors)) == 4
+
+    cb = only(AlgebraOfGraphics.compute_colorbars(fg))
+    @test cb.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 4)])
+    @test cb.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
+
+    # `Date` and `Time` columns take the same path
+    for col in (Date(2024, 1, 1) .+ Month.(0:3), Time(6, 0) .+ Hour.(0:3))
+        fg_col = draw(data((; df.x, df.y, c = col)) * mapping(:x, :y, color = :c))
+        colors_col = only(fg_col.grid[1].entries).named[:color]
+        @test colors_col[1] == cmap[1]
+        @test colors_col[end] == cmap[end]
+    end
+
+    # user-supplied temporal colorrange
+    fg2 = draw(
+        data(df) * mapping(:x, :y, color = :t),
+        scales(Color = (; colorrange = (DateTime(2024, 1, 1), DateTime(2024, 1, 7))))
+    )
+    colors2 = only(fg2.grid[1].entries).named[:color]
+    @test colors2[1] == cmap[1]
+    @test colors2[end] != cmap[end] # data max sits below the colorrange max
+    cb2 = only(AlgebraOfGraphics.compute_colorbars(fg2))
+    @test cb2.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
+
+    # all-equal temporal color values don't error
+    fg3 = draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2))
+    @test only(AlgebraOfGraphics.compute_colorbars(fg3)).limits isa Vector{Float64}
+
+    # heatmap z takes the colorrange from the scale extrema
+    fg4 = draw(
+        data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) *
+            mapping(:x, :y, :z) * visual(Heatmap)
+    )
+    e4 = only(fg4.grid[1].entries)
+    @test e4.named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
+    cb4 = only(AlgebraOfGraphics.compute_colorbars(fg4))
+    @test cb4.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
+
+    # continuous markersize legend shows date-formatted labels
+    fg5 = draw(data(df) * mapping(:x, :y, markersize = :t))
+    mscale = fg5.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    tickvalues, markersizes, ticklabels =
+        AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
+    @test length(tickvalues) == length(markersizes) == length(ticklabels)
+    @test all(l -> occursin("2024", string(l)), ticklabels)
+end
+
 @testset "Aesthetics switch via visual attribute" begin
     spec = data((; x = ["A", "B", "C"], y = 1:3)) * mapping(:x, :y) * visual(BarPlot)
     ag1 = compute_axes_grid(spec)

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -169,62 +169,34 @@ end
     @test labels == ["January", "March", "May"]
     @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
 
-end
-
-@testset "temporal continuous color scales" begin
+    # DateTime as continuous color range
     df = (; x = 1:4, y = [1, 3, 2, 4], t = DateTime(2024, 1, 1) .+ Day.(0:3))
     cmap = Makie.to_colormap(AlgebraOfGraphics.default_colormap())
-
     fg = draw(data(df) * mapping(:x, :y, color = :t))
     colors = only(fg.grid[1].entries).named[:color]
-    @test colors[1] == cmap[1]
-    @test colors[end] == cmap[end]
-    @test length(unique(colors)) == 4
-
+    @test colors[1] == cmap[1] && colors[end] == cmap[end]
     cb = only(AlgebraOfGraphics.compute_colorbars(fg))
     @test cb.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 4)])
     @test cb.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
 
-    # `Date` and `Time` columns take the same path
-    for col in (Date(2024, 1, 1) .+ Month.(0:3), Time(6, 0) .+ Hour.(0:3))
-        fg_col = draw(data((; df.x, df.y, c = col)) * mapping(:x, :y, color = :c))
-        colors_col = only(fg_col.grid[1].entries).named[:color]
-        @test colors_col[1] == cmap[1]
-        @test colors_col[end] == cmap[end]
-    end
-
-    # user-supplied temporal colorrange
+    # a DateTime colorrange is stripped to floats like the data
     fg2 = draw(
         data(df) * mapping(:x, :y, color = :t),
         scales(Color = (; colorrange = (DateTime(2024, 1, 1), DateTime(2024, 1, 7))))
     )
-    colors2 = only(fg2.grid[1].entries).named[:color]
-    @test colors2[1] == cmap[1]
-    @test colors2[end] != cmap[end] # data max sits below the colorrange max
-    cb2 = only(AlgebraOfGraphics.compute_colorbars(fg2))
-    @test cb2.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
+    @test only(fg2.grid[1].entries).named[:color][end] != cmap[end] # data max sits below the colorrange max
+    @test only(AlgebraOfGraphics.compute_colorbars(fg2)).limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
 
-    # all-equal temporal color values don't error
-    fg3 = draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2))
-    @test only(AlgebraOfGraphics.compute_colorbars(fg3)).limits isa Vector{Float64}
+    # all-equal values and the heatmap colorrange path don't error
+    @test draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2)) isa AlgebraOfGraphics.FigureGrid
+    fg3 = draw(data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) * mapping(:x, :y, :z) * visual(Heatmap))
+    @test only(fg3.grid[1].entries).named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
 
-    # heatmap z takes the colorrange from the scale extrema
-    fg4 = draw(
-        data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) *
-            mapping(:x, :y, :z) * visual(Heatmap)
-    )
-    e4 = only(fg4.grid[1].entries)
-    @test e4.named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
-    cb4 = only(AlgebraOfGraphics.compute_colorbars(fg4))
-    @test cb4.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
-
-    # continuous markersize legend shows date-formatted labels
-    fg5 = draw(data(df) * mapping(:x, :y, markersize = :t))
-    mscale = fg5.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
-    tickvalues, markersizes, ticklabels =
-        AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
-    @test length(tickvalues) == length(markersizes) == length(ticklabels)
-    @test all(l -> occursin("2024", string(l)), ticklabels)
+    # DateTime as markersize
+    fg4 = draw(data(df) * mapping(:x, :y, markersize = :t))
+    mscale = fg4.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    _, _, ticklabels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
+    @test all(l -> occursin("2024-01", string(l)), ticklabels)
 end
 
 @testset "Aesthetics switch via visual attribute" begin


### PR DESCRIPTION
Previously, using `mapping(color = :timestamp)` where `timestamp` corresponds to a column containing `DateTime` resulted in comparing floats with DateTimes and errored in Makie's numbers_to_colors.

This PR fixes that by stripping temporal extrema via the existing datetime2float conversion at the same point where the Unitful extension strips units, and reuse DateTicksWrapper so colorbars and markersize/linewidth legends show date-formatted labels.

That enables using temporal columns on continuous color and size scales. 

**AI disclaimer**   
This PR was largely written by Claude, but I did check all of it and didn't see anything obviously wrong (as someone who is not super familiar with this code base, but familiar with good julia code).