### PR TITLE
feat(scales): Temporal columns on continuous scales, plus data-space ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#779](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/779).
+- Continuous scale `ticks` can now be specified in data space on temporal and unit scales, as a vector of `DateTime`s or quantities, or a `(values, labels)` tuple [#779](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/779).
 
 ## v0.13.1 - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#779](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/779).
-- Continuous scale `ticks` can now be specified in data space on temporal and unit scales, as a vector of `DateTime`s or quantities, or a `(values, labels)` tuple [#779](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/779).
+- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#781](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/781).
+- Continuous scale `ticks` can now be specified in data space on temporal and unit scales, as a vector of `DateTime`s or quantities, or a `(values, labels)` tuple [#781](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/781).
 
 ## v0.13.1 - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#778](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/778).
+
 ## v0.13.1 - 2026-07-09
 
 - Unitful and DynamicQuantities columns containing `missing` values no longer error when drawn [#777](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/777).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#778](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/778).
+- Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous `color` (and other continuous aesthetics like `markersize`), with the colorbar showing date-formatted ticks [#779](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/779).
 
 ## v0.13.1 - 2026-07-09
 

--- a/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
+++ b/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
@@ -21,11 +21,15 @@ function dimensionless(x, u::DQ.Quantity{<:Any, <:DQ.Dimensions})
     return DQ.ustrip(xexp)
 end
 
-function AlgebraOfGraphics.strip_units(scale, data::MaybeMissingQuantities)
+function AlgebraOfGraphics.strip_scale(scale::AlgebraOfGraphics.ContinuousScale{<:DQ.Quantity})
     u = AlgebraOfGraphics.getunit(scale)
-    scale_unitless = AlgebraOfGraphics.ContinuousScale(dimensionless.(scale.extrema, u), scale.label, scale.force, scale.props)
+    return AlgebraOfGraphics.ContinuousScale(dimensionless.(scale.extrema, u), scale.label, scale.force, scale.props)
+end
+
+function AlgebraOfGraphics.strip_scale(scale, data::MaybeMissingQuantities)
+    u = AlgebraOfGraphics.getunit(scale)
     data_unitless = AlgebraOfGraphics.map_nonmissing(x -> dimensionless(x, u), data)
-    return scale_unitless, data_unitless
+    return AlgebraOfGraphics.strip_scale(scale), data_unitless
 end
 
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(DQ.ustrip, x)

--- a/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
+++ b/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
@@ -32,6 +32,16 @@ function AlgebraOfGraphics.strip_scale(scale, data::MaybeMissingQuantities)
     return AlgebraOfGraphics.strip_scale(scale), data_unitless
 end
 
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:DQ.Quantity}, ticks::AbstractVector{<:DQ.Quantity})
+    u = AlgebraOfGraphics.getunit(scale)
+    return dimensionless.(ticks, u)
+end
+
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:DQ.Quantity}, (values, labels)::Tuple{<:AbstractVector{<:DQ.Quantity}, <:Any})
+    u = AlgebraOfGraphics.getunit(scale)
+    return dimensionless.(values, u), labels
+end
+
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(DQ.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::DQ.Quantity) = DQ.ustrip(x)
 

--- a/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
+++ b/ext/AlgebraOfGraphicsDynamicQuantitiesExt.jl
@@ -42,6 +42,10 @@ function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{
     return dimensionless.(values, u), labels
 end
 
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:DQ.Quantity}, ::Union{AbstractVector{<:Real}, Tuple{<:AbstractVector{<:Real}, <:Any}})
+    return AlgebraOfGraphics._unitless_ticks_error(scale)
+end
+
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(DQ.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::DQ.Quantity) = DQ.ustrip(x)
 

--- a/ext/AlgebraOfGraphicsUnitfulExt.jl
+++ b/ext/AlgebraOfGraphicsUnitfulExt.jl
@@ -5,11 +5,15 @@ import Unitful
 
 const MaybeMissingQuantities = AbstractVector{<:Union{Missing, Unitful.Quantity}}
 
-function AlgebraOfGraphics.strip_units(scale, data::MaybeMissingQuantities)
+function AlgebraOfGraphics.strip_scale(scale::AlgebraOfGraphics.ContinuousScale{<:Unitful.Quantity})
     u = AlgebraOfGraphics.getunit(scale)
-    scale_unitless = AlgebraOfGraphics.ContinuousScale(Unitful.ustrip.(u, scale.extrema), scale.label, scale.force, scale.props)
+    return AlgebraOfGraphics.ContinuousScale(Unitful.ustrip.(u, scale.extrema), scale.label, scale.force, scale.props)
+end
+
+function AlgebraOfGraphics.strip_scale(scale, data::MaybeMissingQuantities)
+    u = AlgebraOfGraphics.getunit(scale)
     data_unitless = AlgebraOfGraphics.map_nonmissing(x -> Unitful.ustrip(u, x), data)
-    return scale_unitless, data_unitless
+    return AlgebraOfGraphics.strip_scale(scale), data_unitless
 end
 
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(Unitful.ustrip, x)

--- a/ext/AlgebraOfGraphicsUnitfulExt.jl
+++ b/ext/AlgebraOfGraphicsUnitfulExt.jl
@@ -16,6 +16,14 @@ function AlgebraOfGraphics.strip_scale(scale, data::MaybeMissingQuantities)
     return AlgebraOfGraphics.strip_scale(scale), data_unitless
 end
 
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:Unitful.Quantity}, ticks::AbstractVector{<:Unitful.Quantity})
+    return Unitful.ustrip.(AlgebraOfGraphics.getunit(scale), ticks)
+end
+
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:Unitful.Quantity}, (values, labels)::Tuple{<:AbstractVector{<:Unitful.Quantity}, <:Any})
+    return Unitful.ustrip.(AlgebraOfGraphics.getunit(scale), values), labels
+end
+
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(Unitful.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::Unitful.Quantity) = Unitful.ustrip(x)
 AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::MaybeMissingQuantities) =

--- a/ext/AlgebraOfGraphicsUnitfulExt.jl
+++ b/ext/AlgebraOfGraphicsUnitfulExt.jl
@@ -24,6 +24,10 @@ function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{
     return Unitful.ustrip.(AlgebraOfGraphics.getunit(scale), values), labels
 end
 
+function AlgebraOfGraphics.strip_ticks(scale::AlgebraOfGraphics.ContinuousScale{<:Unitful.Quantity}, ::Union{AbstractVector{<:Real}, Tuple{<:AbstractVector{<:Real}, <:Any}})
+    return AlgebraOfGraphics._unitless_ticks_error(scale)
+end
+
 AlgebraOfGraphics.to_unitless_numerical(x::MaybeMissingQuantities) = AlgebraOfGraphics.map_nonmissing(Unitful.ustrip, x)
 AlgebraOfGraphics.to_unitless_numerical(x::Unitful.Quantity) = Unitful.ustrip(x)
 AlgebraOfGraphics.from_unitless_numerical(x̂::AbstractArray{<:Real}, x::MaybeMissingQuantities) =

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -719,8 +719,6 @@ function get_scale(key, aes, scale_mapping, categoricalscales, continuousscales)
     return scale
 end
 
-strip_units(scale, data) = scale, data
-
 function full_rescale(data, key, aes_mapping, scale_mapping, categoricalscales, continuousscales)
     hc_aes = hardcoded_mapping(key)
     aes = hc_aes === nothing ? get(aes_mapping, key, nothing) : hc_aes
@@ -728,8 +726,7 @@ function full_rescale(data, key, aes_mapping, scale_mapping, categoricalscales, 
     scale = get_scale(key, aes, scale_mapping, categoricalscales, continuousscales)
     scale === nothing && return data # verbatim data
     if scale isa ContinuousScale
-        scale, data = strip_units(scale, data)
-        scale = strip_temporal(scale)
+        scale, data = strip_scale(scale, data)
     end
     return full_rescale(data, aes, scale)
 end
@@ -743,7 +740,7 @@ full_rescale(data, aes, scale::CategoricalScale) = rescale(data, scale)
 function nonsingular_colorrange(scale::ContinuousScale)
     props = scale.props.aesprops::AesColorContinuousProps
     cr = @something(props.colorrange, scale.extrema)
-    return nonsingular_limits(map(strip_temporal, cr))
+    return nonsingular_limits(map(to_unitless_numerical, cr))
 end
 
 # expand singular limits to (0, v) or (v, 0) if singular value v is nonzero

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -729,6 +729,7 @@ function full_rescale(data, key, aes_mapping, scale_mapping, categoricalscales, 
     scale === nothing && return data # verbatim data
     if scale isa ContinuousScale
         scale, data = strip_units(scale, data)
+        scale = strip_temporal(scale)
     end
     return full_rescale(data, aes, scale)
 end
@@ -742,7 +743,7 @@ full_rescale(data, aes, scale::CategoricalScale) = rescale(data, scale)
 function nonsingular_colorrange(scale::ContinuousScale)
     props = scale.props.aesprops::AesColorContinuousProps
     cr = @something(props.colorrange, scale.extrema)
-    return nonsingular_limits(cr)
+    return nonsingular_limits(map(strip_temporal, cr))
 end
 
 # expand singular limits to (0, v) or (v, 0) if singular value v is nonzero

--- a/src/guides/colorbar.jl
+++ b/src/guides/colorbar.jl
@@ -57,14 +57,10 @@ end
 
 function continuous_colorbar(colorscale::ContinuousScale)
     label = getlabel(colorscale)
-    # temporal extrema get date-formatted colorbar ticks, other types return `automatic`
-    cbar_ticks = ticks(colorscale.extrema)
-    colorscale = strip_temporal(colorscale)
+    colorscale, cbar_ticks = strip_scale_derive_ticks(colorscale, automatic)
     limits = nonsingular_colorrange(colorscale)
     is_highclipped = limits[2] < colorscale.extrema[2]
     is_lowclipped = limits[1] > colorscale.extrema[1]
-
-    _, limits = strip_units(colorscale, collect(limits))
 
     colormap = @something colorscale.props.aesprops.colormap default_colormap()
     colormap_colors = Makie.to_colormap(colormap)

--- a/src/guides/colorbar.jl
+++ b/src/guides/colorbar.jl
@@ -57,6 +57,9 @@ end
 
 function continuous_colorbar(colorscale::ContinuousScale)
     label = getlabel(colorscale)
+    # temporal extrema get date-formatted colorbar ticks, other types return `automatic`
+    cbar_ticks = ticks(colorscale.extrema)
+    colorscale = strip_temporal(colorscale)
     limits = nonsingular_colorrange(colorscale)
     is_highclipped = limits[2] < colorscale.extrema[2]
     is_lowclipped = limits[1] > colorscale.extrema[1]
@@ -78,6 +81,7 @@ function continuous_colorbar(colorscale::ContinuousScale)
         lowclip,
         highclip,
         scale,
+        ticks = cbar_ticks,
     )
 end
 

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -380,8 +380,10 @@ end
 datavalues_plotvalues_datalabels(aes, scale::CategoricalScale) = datavalues(scale), plotvalues(scale), datalabels(scale)
 function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::ContinuousScale)
     props = scale.props.aesprops::AesMarkerSizeContinuousProps
+    tickfinder = temporal_tickfinder(scale, props.ticks)
+    scale = strip_temporal(scale)
     _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
-    tickvalues, ticklabels = Makie.get_ticks(props.ticks, identity, props.tickformat, s_extrema...)
+    tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]
         error("Range of tick values for MarkerSize scale $(t_extrema) exceeds data range $(s_extrema)")
@@ -391,8 +393,10 @@ function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::Conti
 end
 function datavalues_plotvalues_datalabels(aes::Type{AesLineWidth}, scale::ContinuousScale)
     props = scale.props.aesprops::AesLineWidthContinuousProps
+    tickfinder = temporal_tickfinder(scale, props.ticks)
+    scale = strip_temporal(scale)
     _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
-    tickvalues, ticklabels = Makie.get_ticks(props.ticks, identity, props.tickformat, s_extrema...)
+    tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]
         error("Range of tick values for LineWidth scale $(t_extrema) exceeds data range $(s_extrema)")

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -380,9 +380,8 @@ end
 datavalues_plotvalues_datalabels(aes, scale::CategoricalScale) = datavalues(scale), plotvalues(scale), datalabels(scale)
 function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::ContinuousScale)
     props = scale.props.aesprops::AesMarkerSizeContinuousProps
-    tickfinder = temporal_tickfinder(scale, props.ticks)
-    scale = strip_temporal(scale)
-    _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
+    scale, tickfinder = strip_scale_derive_ticks(scale, props.ticks)
+    s_extrema = nonsingular_limits(scale.extrema)
     tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]
@@ -393,9 +392,8 @@ function datavalues_plotvalues_datalabels(aes::Type{AesMarkerSize}, scale::Conti
 end
 function datavalues_plotvalues_datalabels(aes::Type{AesLineWidth}, scale::ContinuousScale)
     props = scale.props.aesprops::AesLineWidthContinuousProps
-    tickfinder = temporal_tickfinder(scale, props.ticks)
-    scale = strip_temporal(scale)
-    _, s_extrema = strip_units(scale, collect(nonsingular_limits(scale.extrema)))
+    scale, tickfinder = strip_scale_derive_ticks(scale, props.ticks)
+    s_extrema = nonsingular_limits(scale.extrema)
     tickvalues, ticklabels = Makie.get_ticks(tickfinder, identity, props.tickformat, s_extrema...)
     t_extrema = extrema(tickvalues)
     if t_extrema[1] < s_extrema[1] || t_extrema[2] > s_extrema[2]

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -593,16 +593,24 @@ strip_scale(scale, data) = strip_scale(scale), data
 
 # Guides that compute tick labels from stripped extrema (colorbar, markersize/linewidth
 # legends) would label the raw float values, so a default tick finder is swapped for one
-# derived from the typed extrema (`ticks`); user-supplied ticks are kept as-is.
+# derived from the typed extrema (`ticks`); user-supplied ticks pass through `strip_ticks`.
 function strip_scale_derive_ticks(scale::ContinuousScale, tickfinder)
     return strip_scale(scale), guide_tickfinder(scale, tickfinder)
 end
 
 function guide_tickfinder(scale::ContinuousScale, tickfinder)
-    tickfinder === automatic || tickfinder === _default_markersize_ticks || return tickfinder
-    derived = ticks(scale.extrema)
-    return derived === automatic ? tickfinder : derived
+    if tickfinder === automatic || tickfinder === _default_markersize_ticks
+        derived = ticks(scale.extrema)
+        return derived === automatic ? tickfinder : derived
+    end
+    return strip_ticks(scale, tickfinder)
 end
+
+# User-specified ticks are given in data space, so typed tick values (temporal here,
+# quantities in the unit extensions) are converted to the float space the data is in.
+strip_ticks(::ContinuousScale, ticks) = ticks
+strip_ticks(::ContinuousScale{T}, ticks::AbstractVector{<:TimeType}) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
+strip_ticks(::ContinuousScale{T}, ticks::Tuple{<:AbstractVector{<:TimeType}, <:Any}) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
 
 """
     datetimeticks(datetimes::AbstractVector{<:TimeType}, labels::AbstractVector{<:AbstractString})
@@ -814,7 +822,7 @@ function ticks(scale::ContinuousScale)
     return if _ticks === nothing
         ticks(scale.extrema)
     else
-        _ticks
+        strip_ticks(scale, _ticks)
     end
 end
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -579,6 +579,26 @@ datetime2float(x::Union{DateTime, Date}) = datetime2float(DateTime(x) - DateTime
 datetime2float(x::Time) = datetime2float(x - Time(0))
 datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 
+# Temporal data is converted to floats early (`contextfree_rescale`), but scale extrema
+# keep their temporal type so axis ticks can be formatted as dates. Aesthetics that combine
+# data with extrema numerically (color, markersize, linewidth) need the extrema as floats,
+# so scales are passed through `strip_temporal` before rescaling.
+strip_temporal(x::Union{TimeType, Period}) = datetime2float(x)
+strip_temporal(x) = x
+
+strip_temporal(scale::ContinuousScale) = scale
+function strip_temporal(scale::ContinuousScale{<:Union{TimeType, Period}})
+    return ContinuousScale(map(datetime2float, scale.extrema), scale.label, scale.force, scale.props)
+end
+
+# The markersize/linewidth legends compute tick labels from the scale extrema. For temporal
+# extrema, the default numeric tick finder would label the raw millisecond floats, so swap
+# it for date-formatted ticks; user-supplied ticks are kept as-is.
+temporal_tickfinder(::ContinuousScale, ticks) = ticks
+function temporal_tickfinder(::ContinuousScale{T}, ticks) where {T <: TimeType}
+    return ticks === _default_markersize_ticks ? DateTicksWrapper{T}(automatic) : ticks
+end
+
 """
     datetimeticks(datetimes::AbstractVector{<:TimeType}, labels::AbstractVector{<:AbstractString})
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -579,6 +579,12 @@ datetime2float(x::Union{DateTime, Date}) = datetime2float(DateTime(x) - DateTime
 datetime2float(x::Time) = datetime2float(x - Time(0))
 datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 
+struct DateTicksWrapper{T <: TimeType, Ticks}
+    ticks::Ticks
+end
+
+DateTicksWrapper{T}(ticks) where {T <: TimeType} = DateTicksWrapper{T, typeof(ticks)}(ticks)
+
 # Continuous scales can carry non-float extrema: temporal types here, units via the
 # Unitful/DynamicQuantities extensions. Rescaling and guides work in float space, so
 # `strip_scale` converts a scale's extrema (and, for units, the data) to floats.
@@ -616,24 +622,13 @@ strip_ticks(::ContinuousScale, ticks) = ticks
 strip_ticks(::ContinuousScale{T}, ticks) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
 strip_ticks(::ContinuousScale{<:TimeType}, ticks::DateTicksWrapper) = ticks
 
-# Explicit tick positions on a temporal scale must be temporal values; the internal
-# float conversion is not public, so a bare numeric vector is rejected. A `(values, labels)`
-# tuple is still accepted (that is what `datetimeticks` returns).
-function strip_ticks(::ContinuousScale{<:TimeType}, ::AbstractVector{<:Real})
+# Explicit tick positions on a temporal scale must be values of the scale's own time type;
+# the internal float conversion is not public, so plain numbers, as a bare vector or as the
+# values of a `(values, labels)` tuple, are rejected.
+function strip_ticks(::ContinuousScale{T}, ::Union{AbstractVector{<:Real}, Tuple{<:AbstractVector{<:Real}, <:Any}}) where {T <: TimeType}
     return error(
-        "Tick values for a temporal scale must be given as `Date`, `DateTime`, or `Time` values, e.g. `ticks = [Date(2024, 1, 1), Date(2024, 6, 1)]`. " *
-            "Plain numbers are rejected because AlgebraOfGraphics' internal float conversion of temporal values is not part of the public API. Use `datetimeticks` to attach custom labels."
-    )
-end
-
-# Explicit tick positions on a unit scale must carry units, because the display unit can
-# be overridden or derived and plain numbers would silently be taken as that unit. Called
-# from the extensions, where `ContinuousScale{<:Quantity}` can be dispatched on.
-function _unitless_ticks_error(scale::ContinuousScale)
-    u = unit_string(getunit(scale))
-    return error(
-        "Tick values for a scale in units of \"$u\" must carry units themselves, e.g. `ticks = [1, 2, 3] .* u\"$u\"`. " *
-            "Plain numbers are rejected because the display unit can be overridden via `scales(...; unit = ...)` or derived from other scales, which would make their meaning ambiguous."
+        "Tick values for a `$T` scale must be given as `$T` values, e.g. `ticks = [$T(...), $T(...)]` or `ticks = ([$T(...), $T(...)], [\"a\", \"b\"])` to attach custom labels. " *
+            "Plain numbers are rejected because AlgebraOfGraphics' internal float conversion of temporal values is not part of the public API."
     )
 end
 
@@ -655,6 +650,17 @@ The result can be passed to `xticks`, `yticks`, or `zticks`.
 """
 function datetimeticks(f, datetimes::AbstractVector{<:TimeType})
     return datetimeticks(datetimes, map(string ∘ f, datetimes))
+end
+
+# Explicit tick positions on a unit scale must carry units, because the display unit can
+# be overridden or derived and plain numbers would silently be taken as that unit. Called
+# from the extensions, where `ContinuousScale{<:Quantity}` can be dispatched on.
+function _unitless_ticks_error(scale::ContinuousScale)
+    u = unit_string(getunit(scale))
+    return error(
+        "Tick values for a scale in units of \"$u\" must carry units themselves, e.g. `ticks = [1, 2, 3] .* u\"$u\"`. " *
+            "Plain numbers are rejected because the display unit can be overridden via `scales(...; unit = ...)` or derived from other scales, which would make their meaning ambiguous."
+    )
 end
 
 # Analyses like Loess, GLM and StatsBase.Histogram need numeric inputs, so temporal
@@ -853,12 +859,6 @@ end
 
 ticks((min, max)::NTuple{2, Any}) = automatic
 
-struct DateTicksWrapper{T <: TimeType, Ticks}
-    ticks::Ticks
-end
-
-DateTicksWrapper{T}(ticks) where {T <: TimeType} = DateTicksWrapper{T, typeof(ticks)}(ticks)
-
 const DATETIME_EPOCH = DateTime(2020, 01, 01)
 
 function float_to_datetime(vmin, vmax)
@@ -878,17 +878,16 @@ function float_to_time(vmin, vmax)
     return vmin_t, vmax_t
 end
 
-# tick values that are already floats (e.g. from `datetimeticks`) pass through unchanged
 function Makie.get_ticks(t::DateTicksWrapper{T}, scale, formatter, vmin, vmax) where {T <: Union{DateTime, Date}}
     vmin_dt, vmax_dt = float_to_datetime(vmin, vmax)
     datetimes, labels = Makie.get_ticks(t.ticks, scale, formatter, vmin_dt, vmax_dt)
-    return to_unitless_numerical(datetimes), labels
+    return map(datetime2float, datetimes), labels
 end
 
 function Makie.get_ticks(t::DateTicksWrapper{Time}, scale, formatter, vmin, vmax)
     vmin_t, vmax_t = float_to_time(vmin, vmax)
     times, labels = Makie.get_ticks(t.ticks, scale, formatter, vmin_t, vmax_t)
-    return to_unitless_numerical(times), labels
+    return map(datetime2float, times), labels
 end
 
 function ticks(::NTuple{2, T}) where {T <: TimeType}

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -616,6 +616,16 @@ strip_ticks(::ContinuousScale, ticks) = ticks
 strip_ticks(::ContinuousScale{T}, ticks) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
 strip_ticks(::ContinuousScale{<:TimeType}, ticks::DateTicksWrapper) = ticks
 
+# Explicit tick positions on a temporal scale must be temporal values; the internal
+# float conversion is not public, so a bare numeric vector is rejected. A `(values, labels)`
+# tuple is still accepted (that is what `datetimeticks` returns).
+function strip_ticks(::ContinuousScale{<:TimeType}, ::AbstractVector{<:Real})
+    return error(
+        "Tick values for a temporal scale must be given as `Date`, `DateTime`, or `Time` values, e.g. `ticks = [Date(2024, 1, 1), Date(2024, 6, 1)]`. " *
+            "Plain numbers are rejected because AlgebraOfGraphics' internal float conversion of temporal values is not part of the public API. Use `datetimeticks` to attach custom labels."
+    )
+end
+
 # Explicit tick positions on a unit scale must carry units, because the display unit can
 # be overridden or derived and plain numbers would silently be taken as that unit. Called
 # from the extensions, where `ContinuousScale{<:Quantity}` can be dispatched on.

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -606,11 +606,15 @@ function guide_tickfinder(scale::ContinuousScale, tickfinder)
     return strip_ticks(scale, tickfinder)
 end
 
-# User-specified ticks are given in data space, so typed tick values (temporal here,
-# quantities in the unit extensions) are converted to the float space the data is in.
+# User-specified ticks are given in data space and are converted to the float space the
+# data is in. Mirroring Makie's dim conversions, temporal scales interpret any tick spec
+# in date space by wrapping it in `DateTicksWrapper` (so date vectors, `StepRange`s like
+# `Date(2024):Month(1):Date(2025)` and `Makie.DateTimeTicks` all work), while unit scales
+# find ticks in float space like a plain axis and only need their tick values converted
+# to the display unit (methods in the Unitful/DynamicQuantities extensions).
 strip_ticks(::ContinuousScale, ticks) = ticks
-strip_ticks(::ContinuousScale{T}, ticks::AbstractVector{<:TimeType}) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
-strip_ticks(::ContinuousScale{T}, ticks::Tuple{<:AbstractVector{<:TimeType}, <:Any}) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
+strip_ticks(::ContinuousScale{T}, ticks) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
+strip_ticks(::ContinuousScale{<:TimeType}, ticks::DateTicksWrapper) = ticks
 
 """
     datetimeticks(datetimes::AbstractVector{<:TimeType}, labels::AbstractVector{<:AbstractString})
@@ -853,16 +857,17 @@ function float_to_time(vmin, vmax)
     return vmin_t, vmax_t
 end
 
+# tick values that are already floats (e.g. from `datetimeticks`) pass through unchanged
 function Makie.get_ticks(t::DateTicksWrapper{T}, scale, formatter, vmin, vmax) where {T <: Union{DateTime, Date}}
     vmin_dt, vmax_dt = float_to_datetime(vmin, vmax)
     datetimes, labels = Makie.get_ticks(t.ticks, scale, formatter, vmin_dt, vmax_dt)
-    return map(datetime2float, datetimes), labels
+    return to_unitless_numerical(datetimes), labels
 end
 
 function Makie.get_ticks(t::DateTicksWrapper{Time}, scale, formatter, vmin, vmax)
     vmin_t, vmax_t = float_to_time(vmin, vmax)
     times, labels = Makie.get_ticks(t.ticks, scale, formatter, vmin_t, vmax_t)
-    return map(datetime2float, times), labels
+    return to_unitless_numerical(times), labels
 end
 
 function ticks(::NTuple{2, T}) where {T <: TimeType}

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -583,6 +583,11 @@ datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 # keep their temporal type so axis ticks can be formatted as dates. Aesthetics that combine
 # data with extrema numerically (color, markersize, linewidth) need the extrema as floats,
 # so scales are passed through `strip_temporal` before rescaling.
+# This is the temporal analogue of `strip_units`; they differ because units need a target
+# unit (`props.unit`) and data conversion, while temporal data is float already. Should a
+# third non-float continuous family ever arise, consider unifying the pattern shared by
+# the colorbar and markersize/linewidth legends — "derive a tick finder from the typed
+# extrema, then strip the scale to float space" — into a single seam.
 strip_temporal(x::Union{TimeType, Period}) = datetime2float(x)
 strip_temporal(x) = x
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -616,6 +616,17 @@ strip_ticks(::ContinuousScale, ticks) = ticks
 strip_ticks(::ContinuousScale{T}, ticks) where {T <: TimeType} = DateTicksWrapper{T}(ticks)
 strip_ticks(::ContinuousScale{<:TimeType}, ticks::DateTicksWrapper) = ticks
 
+# Explicit tick positions on a unit scale must carry units, because the display unit can
+# be overridden or derived and plain numbers would silently be taken as that unit. Called
+# from the extensions, where `ContinuousScale{<:Quantity}` can be dispatched on.
+function _unitless_ticks_error(scale::ContinuousScale)
+    u = unit_string(getunit(scale))
+    return error(
+        "Tick values for a scale in units of \"$u\" must carry units themselves, e.g. `ticks = [1, 2, 3] .* u\"$u\"`. " *
+            "Plain numbers are rejected because the display unit can be overridden via `scales(...; unit = ...)` or derived from other scales, which would make their meaning ambiguous."
+    )
+end
+
 """
     datetimeticks(datetimes::AbstractVector{<:TimeType}, labels::AbstractVector{<:AbstractString})
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -579,29 +579,29 @@ datetime2float(x::Union{DateTime, Date}) = datetime2float(DateTime(x) - DateTime
 datetime2float(x::Time) = datetime2float(x - Time(0))
 datetime2float(x::Period) = Millisecond(x) / Millisecond(1)
 
-# Temporal data is converted to floats early (`contextfree_rescale`), but scale extrema
-# keep their temporal type so axis ticks can be formatted as dates. Aesthetics that combine
-# data with extrema numerically (color, markersize, linewidth) need the extrema as floats,
-# so scales are passed through `strip_temporal` before rescaling.
-# This is the temporal analogue of `strip_units`; they differ because units need a target
-# unit (`props.unit`) and data conversion, while temporal data is float already. Should a
-# third non-float continuous family ever arise, consider unifying the pattern shared by
-# the colorbar and markersize/linewidth legends — "derive a tick finder from the typed
-# extrema, then strip the scale to float space" — into a single seam.
-strip_temporal(x::Union{TimeType, Period}) = datetime2float(x)
-strip_temporal(x) = x
-
-strip_temporal(scale::ContinuousScale) = scale
-function strip_temporal(scale::ContinuousScale{<:Union{TimeType, Period}})
+# Continuous scales can carry non-float extrema: temporal types here, units via the
+# Unitful/DynamicQuantities extensions. Rescaling and guides work in float space, so
+# `strip_scale` converts a scale's extrema (and, for units, the data) to floats.
+# Temporal data needs no conversion because it is turned into floats early
+# (`contextfree_rescale`); only the extrema keep their type so guides can derive
+# date-formatted ticks from them before stripping (`strip_scale_derive_ticks`).
+strip_scale(scale::ContinuousScale) = scale
+function strip_scale(scale::ContinuousScale{<:Union{TimeType, Period}})
     return ContinuousScale(map(datetime2float, scale.extrema), scale.label, scale.force, scale.props)
 end
+strip_scale(scale, data) = strip_scale(scale), data
 
-# The markersize/linewidth legends compute tick labels from the scale extrema. For temporal
-# extrema, the default numeric tick finder would label the raw millisecond floats, so swap
-# it for date-formatted ticks; user-supplied ticks are kept as-is.
-temporal_tickfinder(::ContinuousScale, ticks) = ticks
-function temporal_tickfinder(::ContinuousScale{T}, ticks) where {T <: TimeType}
-    return ticks === _default_markersize_ticks ? DateTicksWrapper{T}(automatic) : ticks
+# Guides that compute tick labels from stripped extrema (colorbar, markersize/linewidth
+# legends) would label the raw float values, so a default tick finder is swapped for one
+# derived from the typed extrema (`ticks`); user-supplied ticks are kept as-is.
+function strip_scale_derive_ticks(scale::ContinuousScale, tickfinder)
+    return strip_scale(scale), guide_tickfinder(scale, tickfinder)
+end
+
+function guide_tickfinder(scale::ContinuousScale, tickfinder)
+    tickfinder === automatic || tickfinder === _default_markersize_ticks || return tickfinder
+    derived = ticks(scale.extrema)
+    return derived === automatic ? tickfinder : derived
 end
 
 """

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -160,7 +160,6 @@ end
     @test length(floats) > 0
     @test length(floats) == length(labels)
 
-    # datetimeticks public API unchanged
     floats, labels = datetimeticks(month, [Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
     @test labels == ["1", "3", "5"]
     @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
@@ -168,6 +167,10 @@ end
     floats, labels = datetimeticks([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)], ["January", "March", "May"])
     @test labels == ["January", "March", "May"]
     @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+
+    df_at = (; x = 1:3, y = [1, 3, 2], t = [Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+    fg_at = draw(data(df_at) * mapping(:t, :y), axis = (; xticks = datetimeticks(month, df_at.t)))
+    @test only(fg_at.grid).axis.xticks[] == (datetime2float.(df_at.t), ["1", "3", "5"])
 
     # DateTime as continuous color range
     df = (; x = 1:4, y = [1, 3, 2, 4], t = DateTime(2024, 1, 1) .+ Day.(0:3))
@@ -232,7 +235,7 @@ end
     @test tickvalues == datetime2float.(DateTime.(steps))
     @test labels == ["2024-01", "2024-03", "2024-05"]
 
-    fg10 = draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = datetimeticks(Dates.monthname, [Date(2024, 1, 1), Date(2024, 4, 1)]))))
+    fg10 = draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = ([Date(2024, 1, 1), Date(2024, 4, 1)], ["January", "April"]))))
     tickvalues, labels = Makie.get_ticks(only(fg10.grid).axis.xticks[], identity, automatic, lo, hi)
     @test tickvalues == datetime2float.([Date(2024, 1, 1), Date(2024, 4, 1)])
     @test labels == ["January", "April"]
@@ -242,8 +245,9 @@ end
     _, _, labels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale11)
     @test labels == ["2024-01", "2024-04"]
 
-    @test_throws_message "must be given as `Date`, `DateTime`, or `Time`" draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = [1, 2, 3])))
-    @test_throws_message "must be given as `Date`, `DateTime`, or `Time`" draw(data(df_m) * mapping(:x, :y, markersize = :t), scales(MarkerSize = (; ticks = 1:3)))
+    @test_throws_message "Tick values for a `Date` scale must be given as `Date` values" draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = [1, 2, 3])))
+    @test_throws_message "Tick values for a `Date` scale must be given as `Date` values" draw(data(df_m) * mapping(:x, :y, markersize = :t), scales(MarkerSize = (; ticks = 1:3)))
+    @test_throws_message "Tick values for a `Date` scale must be given as `Date` values" draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = ([1, 2, 3], ["a", "b", "c"]))))
 end
 
 @testset "Aesthetics switch via visual attribute" begin

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -395,6 +395,10 @@ if VERSION >= v"1.9"
             tickvalues, _, ticklabels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
             @test tickvalues == [10.0, 30.0]
             @test ticklabels == ["10", "30"]
+
+            @test_throws_message "must carry units" draw(data(df) * mapping(:q, :y), scales(X = (; ticks = [1, 2, 3])))
+            @test_throws_message "must carry units" draw(data(df) * mapping(:q, :y), scales(X = (; ticks = ([1, 2, 3], ["a", "b", "c"]))))
+            @test_throws_message "must carry units" draw(data((; x = 1:4, df.y, df.q)) * mapping(:x, :y, markersize = :q), scales(MarkerSize = (; ticks = [1, 2, 3])))
         end
 
         @test AlgebraOfGraphics.dimensionally_compatible(nothing, nothing)

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -171,6 +171,62 @@ end
 
 end
 
+@testset "temporal continuous color scales" begin
+    df = (; x = 1:4, y = [1, 3, 2, 4], t = DateTime(2024, 1, 1) .+ Day.(0:3))
+    cmap = Makie.to_colormap(AlgebraOfGraphics.default_colormap())
+
+    fg = draw(data(df) * mapping(:x, :y, color = :t))
+    colors = only(fg.grid[1].entries).named[:color]
+    @test colors[1] == cmap[1]
+    @test colors[end] == cmap[end]
+    @test length(unique(colors)) == 4
+
+    cb = only(AlgebraOfGraphics.compute_colorbars(fg))
+    @test cb.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 4)])
+    @test cb.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
+
+    # `Date` and `Time` columns take the same path
+    for col in (Date(2024, 1, 1) .+ Month.(0:3), Time(6, 0) .+ Hour.(0:3))
+        fg_col = draw(data((; df.x, df.y, c = col)) * mapping(:x, :y, color = :c))
+        colors_col = only(fg_col.grid[1].entries).named[:color]
+        @test colors_col[1] == cmap[1]
+        @test colors_col[end] == cmap[end]
+    end
+
+    # user-supplied temporal colorrange
+    fg2 = draw(
+        data(df) * mapping(:x, :y, color = :t),
+        scales(Color = (; colorrange = (DateTime(2024, 1, 1), DateTime(2024, 1, 7))))
+    )
+    colors2 = only(fg2.grid[1].entries).named[:color]
+    @test colors2[1] == cmap[1]
+    @test colors2[end] != cmap[end] # data max sits below the colorrange max
+    cb2 = only(AlgebraOfGraphics.compute_colorbars(fg2))
+    @test cb2.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
+
+    # all-equal temporal color values don't error
+    fg3 = draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2))
+    @test only(AlgebraOfGraphics.compute_colorbars(fg3)).limits isa Vector{Float64}
+
+    # heatmap z takes the colorrange from the scale extrema
+    fg4 = draw(
+        data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) *
+            mapping(:x, :y, :z) * visual(Heatmap)
+    )
+    e4 = only(fg4.grid[1].entries)
+    @test e4.named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
+    cb4 = only(AlgebraOfGraphics.compute_colorbars(fg4))
+    @test cb4.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
+
+    # continuous markersize legend shows date-formatted labels
+    fg5 = draw(data(df) * mapping(:x, :y, markersize = :t))
+    mscale = fg5.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    tickvalues, markersizes, ticklabels =
+        AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
+    @test length(tickvalues) == length(markersizes) == length(ticklabels)
+    @test all(l -> occursin("2024", string(l)), ticklabels)
+end
+
 @testset "Aesthetics switch via visual attribute" begin
     spec = data((; x = ["A", "B", "C"], y = 1:3)) * mapping(:x, :y) * visual(BarPlot)
     ag1 = compute_axes_grid(spec)

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -169,62 +169,34 @@ end
     @test labels == ["January", "March", "May"]
     @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
 
-end
-
-@testset "temporal continuous color scales" begin
+    # DateTime as continuous color range
     df = (; x = 1:4, y = [1, 3, 2, 4], t = DateTime(2024, 1, 1) .+ Day.(0:3))
     cmap = Makie.to_colormap(AlgebraOfGraphics.default_colormap())
-
     fg = draw(data(df) * mapping(:x, :y, color = :t))
     colors = only(fg.grid[1].entries).named[:color]
-    @test colors[1] == cmap[1]
-    @test colors[end] == cmap[end]
-    @test length(unique(colors)) == 4
-
+    @test colors[1] == cmap[1] && colors[end] == cmap[end]
     cb = only(AlgebraOfGraphics.compute_colorbars(fg))
     @test cb.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 4)])
     @test cb.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
 
-    # `Date` and `Time` columns take the same path
-    for col in (Date(2024, 1, 1) .+ Month.(0:3), Time(6, 0) .+ Hour.(0:3))
-        fg_col = draw(data((; df.x, df.y, c = col)) * mapping(:x, :y, color = :c))
-        colors_col = only(fg_col.grid[1].entries).named[:color]
-        @test colors_col[1] == cmap[1]
-        @test colors_col[end] == cmap[end]
-    end
-
-    # user-supplied temporal colorrange
+    # a DateTime colorrange is stripped to floats like the data
     fg2 = draw(
         data(df) * mapping(:x, :y, color = :t),
         scales(Color = (; colorrange = (DateTime(2024, 1, 1), DateTime(2024, 1, 7))))
     )
-    colors2 = only(fg2.grid[1].entries).named[:color]
-    @test colors2[1] == cmap[1]
-    @test colors2[end] != cmap[end] # data max sits below the colorrange max
-    cb2 = only(AlgebraOfGraphics.compute_colorbars(fg2))
-    @test cb2.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
+    @test only(fg2.grid[1].entries).named[:color][end] != cmap[end] # data max sits below the colorrange max
+    @test only(AlgebraOfGraphics.compute_colorbars(fg2)).limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
 
-    # all-equal temporal color values don't error
-    fg3 = draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2))
-    @test only(AlgebraOfGraphics.compute_colorbars(fg3)).limits isa Vector{Float64}
+    # all-equal values and the heatmap colorrange path don't error
+    @test draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2)) isa AlgebraOfGraphics.FigureGrid
+    fg3 = draw(data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) * mapping(:x, :y, :z) * visual(Heatmap))
+    @test only(fg3.grid[1].entries).named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
 
-    # heatmap z takes the colorrange from the scale extrema
-    fg4 = draw(
-        data((; x = [1, 1, 2, 2], y = [1, 2, 1, 2], z = DateTime(2024, 1, 1) .+ Day.(0:3))) *
-            mapping(:x, :y, :z) * visual(Heatmap)
-    )
-    e4 = only(fg4.grid[1].entries)
-    @test e4.named[:colorrange] == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
-    cb4 = only(AlgebraOfGraphics.compute_colorbars(fg4))
-    @test cb4.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
-
-    # continuous markersize legend shows date-formatted labels
-    fg5 = draw(data(df) * mapping(:x, :y, markersize = :t))
-    mscale = fg5.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
-    tickvalues, markersizes, ticklabels =
-        AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
-    @test length(tickvalues) == length(markersizes) == length(ticklabels)
-    @test all(l -> occursin("2024", string(l)), ticklabels)
+    # DateTime as markersize
+    fg4 = draw(data(df) * mapping(:x, :y, markersize = :t))
+    mscale = fg4.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    _, _, ticklabels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
+    @test all(l -> occursin("2024-01", string(l)), ticklabels)
 end
 
 @testset "Aesthetics switch via visual attribute" begin

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -241,6 +241,9 @@ end
     mscale11 = fg11.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
     _, _, labels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale11)
     @test labels == ["2024-01", "2024-04"]
+
+    @test_throws_message "must be given as `Date`, `DateTime`, or `Time`" draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = [1, 2, 3])))
+    @test_throws_message "must be given as `Date`, `DateTime`, or `Time`" draw(data(df_m) * mapping(:x, :y, markersize = :t), scales(MarkerSize = (; ticks = 1:3)))
 end
 
 @testset "Aesthetics switch via visual attribute" begin

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -217,6 +217,30 @@ end
     tickvalues, _, labels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale7)
     @test tickvalues == datetime2float.(user_dts)
     @test labels == ["2024-01-01T00:00:00", "2024-01-03T00:00:00"]
+
+    # any tick spec on a temporal scale runs in date space
+    df_m = (; x = 1:6, y = [1, 3, 2, 4, 3, 5], t = Date(2024, 1, 1) .+ Month.(0:5))
+    lo, hi = datetime2float(DateTime(2024, 1, 1)), datetime2float(DateTime(2024, 6, 1))
+    steps = Date(2024, 1, 1):Month(2):Date(2024, 6, 1)
+    fg8 = draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = steps)))
+    tickvalues, labels = Makie.get_ticks(only(fg8.grid).axis.xticks[], identity, automatic, lo, hi)
+    @test tickvalues == datetime2float.(DateTime.(steps))
+    @test labels == ["2024-01", "2024-03", "2024-05"]
+
+    fg9 = draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = Makie.DateTimeTicks(3))))
+    tickvalues, labels = Makie.get_ticks(only(fg9.grid).axis.xticks[], identity, automatic, lo, hi)
+    @test tickvalues == datetime2float.(DateTime.(steps))
+    @test labels == ["2024-01", "2024-03", "2024-05"]
+
+    fg10 = draw(data(df_m) * mapping(:t, :y), scales(X = (; ticks = datetimeticks(Dates.monthname, [Date(2024, 1, 1), Date(2024, 4, 1)]))))
+    tickvalues, labels = Makie.get_ticks(only(fg10.grid).axis.xticks[], identity, automatic, lo, hi)
+    @test tickvalues == datetime2float.([Date(2024, 1, 1), Date(2024, 4, 1)])
+    @test labels == ["January", "April"]
+
+    fg11 = draw(data(df_m) * mapping(:x, :y, markersize = :t), scales(MarkerSize = (; ticks = [Date(2024, 1, 1), Date(2024, 4, 1)], tickformat = "yyyy-mm")))
+    mscale11 = fg11.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    _, _, labels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale11)
+    @test labels == ["2024-01", "2024-04"]
 end
 
 @testset "Aesthetics switch via visual attribute" begin

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -197,6 +197,26 @@ end
     mscale = fg4.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
     _, _, ticklabels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
     @test all(l -> occursin("2024-01", string(l)), ticklabels)
+
+    # user ticks given as DateTime values
+    user_dts = [DateTime(2024, 1, 1), DateTime(2024, 1, 3)]
+    fg5 = draw(data(df) * mapping(:t, :y), scales(X = (; ticks = user_dts)))
+    xticks = only(fg5.grid).axis.xticks[]
+    @test xticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
+    tickvalues, labels = Makie.get_ticks(xticks, identity, automatic, datetime2float(df.t[1]), datetime2float(df.t[end]))
+    @test tickvalues == datetime2float.(user_dts)
+    @test labels == ["2024-01-01T00:00:00", "2024-01-03T00:00:00"]
+
+    fg6 = draw(data(df) * mapping(:t, :y), scales(X = (; ticks = (user_dts, ["start", "mid"]))))
+    tickvalues, labels = Makie.get_ticks(only(fg6.grid).axis.xticks[], identity, automatic, datetime2float(df.t[1]), datetime2float(df.t[end]))
+    @test tickvalues == datetime2float.(user_dts)
+    @test labels == ["start", "mid"]
+
+    fg7 = draw(data(df) * mapping(:x, :y, markersize = :t), scales(MarkerSize = (; ticks = user_dts)))
+    mscale7 = fg7.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+    tickvalues, _, labels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale7)
+    @test tickvalues == datetime2float.(user_dts)
+    @test labels == ["2024-01-01T00:00:00", "2024-01-03T00:00:00"]
 end
 
 @testset "Aesthetics switch via visual attribute" begin
@@ -336,6 +356,21 @@ if VERSION >= v"1.9"
             @test AlgebraOfGraphics.getunit(xscale) == xoverride
             yscale = fg2.grid[].continuousscales[AlgebraOfGraphics.AesY][nothing]
             @test AlgebraOfGraphics.getunit(yscale) == yoverride
+        end
+
+        for (mm, cm) in [(U.u"mm", U.u"cm"), (D.us"mm", D.us"cm")]
+            df = (; y = [1, 3, 2, 4], q = [10.0, 20.0, 30.0, 40.0] .* mm)
+            fg = draw(data(df) * mapping(:q, :y), scales(X = (; unit = cm, ticks = [10.0, 30.0] .* mm)))
+            @test only(fg.grid).axis.xticks[] == [1, 3]
+
+            fg2 = draw(data(df) * mapping(:q, :y), scales(X = (; ticks = ([10.0, 30.0] .* mm, ["low", "high"]))))
+            @test only(fg2.grid).axis.xticks[] == ([10.0, 30.0], ["low", "high"])
+
+            fg3 = draw(data((; x = 1:4, df.y, df.q)) * mapping(:x, :y, markersize = :q), scales(MarkerSize = (; ticks = [10.0, 30.0] .* mm)))
+            mscale = fg3.grid[].continuousscales[AlgebraOfGraphics.AesMarkerSize][nothing]
+            tickvalues, _, ticklabels = AlgebraOfGraphics.datavalues_plotvalues_datalabels(AlgebraOfGraphics.AesMarkerSize, mscale)
+            @test tickvalues == [10.0, 30.0]
+            @test ticklabels == ["10", "30"]
         end
 
         @test AlgebraOfGraphics.dimensionally_compatible(nothing, nothing)

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -176,7 +176,7 @@ end
     colors = only(fg.grid[1].entries).named[:color]
     @test colors[1] == cmap[1] && colors[end] == cmap[end]
     cb = only(AlgebraOfGraphics.compute_colorbars(fg))
-    @test cb.limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 4)])
+    @test cb.limits == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 4)))
     @test cb.ticks isa AlgebraOfGraphics.DateTicksWrapper{DateTime}
 
     # a DateTime colorrange is stripped to floats like the data
@@ -185,7 +185,7 @@ end
         scales(Color = (; colorrange = (DateTime(2024, 1, 1), DateTime(2024, 1, 7))))
     )
     @test only(fg2.grid[1].entries).named[:color][end] != cmap[end] # data max sits below the colorrange max
-    @test only(AlgebraOfGraphics.compute_colorbars(fg2)).limits == datetime2float.([DateTime(2024, 1, 1), DateTime(2024, 1, 7)])
+    @test only(AlgebraOfGraphics.compute_colorbars(fg2)).limits == datetime2float.((DateTime(2024, 1, 1), DateTime(2024, 1, 7)))
 
     # all-equal values and the heatmap colorrange path don't error
     @test draw(data((; df.x, df.y, t2 = fill(DateTime(2024, 1, 1), 4))) * mapping(:x, :y, color = :t2)) isa AlgebraOfGraphics.FigureGrid


### PR DESCRIPTION
Continuation of #779 (which this supersedes), picking up @jlbosse's work on temporal columns for continuous scales and building the tick handling out further.

Temporal columns (`DateTime`, `Date`, `Time`) can now be mapped to continuous aesthetics like `color` and `markersize`, not just positional axes. Previously this compared floats with `DateTime`s and errored in Makie's `numbers_to_colors`. The colorbar and the size legends format their ticks as dates.

```julia
df = (; x = 1:12, y = cos.(1:12), t = Date(2024, 1, 1) .+ Month.(0:11))
draw(data(df) * mapping(:x, :y, color = :t, markersize = :t) * visual(Scatter, colormap = :viridis))
```

<img width="600" height="450" alt="temporal color and markersize with date-formatted guides" src="https://github.com/user-attachments/assets/034ce4fb-eb95-414d-8b7f-26435e05b3af">

Under the hood the unit-stripping (`strip_units`) and temporal-stripping mechanisms are unified into one `strip_scale` seam, since both just convert a scale's non-float extrema (and, for units, the data) into the float space that rescaling and guides work in.

On top of that, continuous scale `ticks` can now be given in data space, and are interpreted the way you'd expect if Makie's dim conversion were temporal or unitful. On a temporal scale any tick spec is handled in date space, so a vector of dates, a `StepRange`, or a `Makie.DateTimeTicks` all work:

```julia
scales(X = (; ticks = Date(2024, 1, 1):Month(3):Date(2024, 12, 1)))
scales(X = (; ticks = ([Date(2024, 1, 1), Date(2024, 6, 1)], ["start", "mid"])))
```

On a unit scale ticks are found in the float display-unit space like a plain axis, so tick values just need to carry units:

```julia
scales(X = (; ticks = [10, 20, 30] .* u"cm"))
```

Passing plain numbers where the scale needs typed values now errors with a message naming what's required, instead of silently taking them as raw internal floats (temporal) or display-unit numbers (units), both of which are ambiguous because AlgebraOfGraphics' float conversion isn't public and the display unit can be overridden or derived.
