### PR TITLE
fix(scales): Keep verbatim data out of other layers' scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.2 - 2026-09-03
+
 - Mappings with `verbatim` no longer pick up another layer's scale for the same aesthetic [#786](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/786).
 
 ## v0.13.1 - 2026-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Mappings with `verbatim` no longer pick up another layer's scale for the same aesthetic [#786](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/786).
+
 ## v0.13.1 - 2026-07-09
 
 - Unitful and DynamicQuantities columns containing `missing` values no longer error when drawn [#777](https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/777).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi", "Julius Krumbiegel"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -722,11 +722,14 @@ end
 strip_units(scale, data) = scale, data
 
 function full_rescale(data, key, aes_mapping, scale_mapping, categoricalscales, continuousscales)
+    is_verbatim(data) && return data
     hc_aes = hardcoded_mapping(key)
     aes = hc_aes === nothing ? get(aes_mapping, key, nothing) : hc_aes
-    aes === nothing && return data # verbatim data
+    if aes === nothing
+        error("Found no aesthetic for key $(repr(key)), only verbatim data may use a key that is not part of a plot type's aesthetic mapping and that is handled above.")
+    end
     scale = get_scale(key, aes, scale_mapping, categoricalscales, continuousscales)
-    scale === nothing && return data # verbatim data
+    scale === nothing && return data
     if scale isa ContinuousScale
         scale, data = strip_units(scale, data)
     end
@@ -829,6 +832,9 @@ function full_rescale(data, aes::Type{<:Union{AesX, AesY, AesZ, AesDeltaX, AesDe
 end
 
 function numerical_rescale(values, key, aes_mapping, scale_mapping, categoricalscales, continuousscales)
+    if is_verbatim(values)
+        error("Cannot do numerical rescale on verbatim data for $(repr(key))")
+    end
     aes = aes_mapping[key]
     scale = get_scale(key, aes, scale_mapping, categoricalscales, continuousscales)
 
@@ -1037,7 +1043,7 @@ function compute_plot_dependent_attributes!(::Type{T}, pl::ProcessedLayer) where
 
     flat = reduce(vcat, xdata)
     isempty(flat) && return
-    rescaled = contextfree_rescale(flat)
+    rescaled = unwrap_verbatim(contextfree_rescale(flat))
     s = unique!(sort(rescaled))
 
     width = if length(s) <= 1

--- a/src/entries.jl
+++ b/src/entries.jl
@@ -7,6 +7,12 @@ struct Entry
     plottype::PlotType
     positional::Arguments
     named::NamedArguments
+
+    # an `Entry` holds plot-ready data, so the `Verbatim` wrappers that mark data
+    # which no scale applies to during scale resolution are stripped here
+    function Entry(plottype::PlotType, positional, named)
+        return new(plottype, map(unwrap_verbatim, positional), map(unwrap_verbatim, named))
+    end
 end
 
 # Use technique from https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/289

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -690,8 +690,16 @@ elementwise_rescale(::Missing) = missing
 # if there were only missings, breaking some plotting scenarios due to downstream Makie failures to convert,
 # this way we at least pass through data that doesn't look like it should be rescaled, also saving some memory,
 # which keeps the annoying behavior for those types but can't really be avoided easily
-contextfree_rescale(values::AbstractArray{<:Union{TimeType, Period, Verbatim, Missing}}) = map(elementwise_rescale, values)
+contextfree_rescale(values::AbstractArray{<:Union{TimeType, Period, Missing}}) = map(elementwise_rescale, values)
 contextfree_rescale(values::AbstractArray) = values
+
+# `Verbatim` values stay wrapped through `contextfree_rescale` so that scale resolution can tell them apart
+# from data of the same aesthetic that does belong to a scale, they are unwrapped when entries are built
+is_verbatim(values::AbstractArray) = eltype(values) !== Missing && nonmissingtype(eltype(values)) <: Verbatim
+is_verbatim(_) = false
+
+unwrap_verbatim(v::Verbatim) = v[]
+unwrap_verbatim(values) = is_verbatim(values) ? map(elementwise_rescale, values) : values
 
 rescale(values, ::Nothing; allow_continuous = true) = values
 

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -281,6 +281,18 @@ end
     @test e2.named[:color] == colors[6:10]
 end
 
+@testset "verbatim bypasses a scale of the same aesthetic in another layer" begin
+    colors = [:black, :black, :black, :red]
+    spec = mapping([1, 2, 1, 2], [1, 2, 2, 1]) * (
+        mapping([1, 2, 3, 4]) * visual(Heatmap) +
+            mapping(text = ["A", "B", "C", "D"] => verbatim, color = colors => verbatim) * visual(Makie.Text)
+    )
+
+    ag = compute_axes_grid(spec, scales())
+    entry = only(filter(e -> e.plottype <: Makie.Text, ag[1].entries))
+    @test entry.named[:color] == colors
+end
+
 @testset "hardcoded categoricals work with continuous data" begin
 
     hardcodeds = [:layout, :col, :row, :group]


### PR DESCRIPTION
Fixes #785

Data passed with `verbatim` is supposed to bypass the scale system, and it does bypass scale fitting, but not scale application. The `Verbatim` wrappers were stripped before entries were built, so the rescaling step could not tell verbatim data apart from data belonging to a scale anymore. It looked a scale up by aesthetic plus scale id, and verbatim data without an explicit scale id matched any default scale of the same aesthetic, including one from a completely different layer:

```julia
df = (; x = [1, 2, 1, 2], y = [1, 2, 2, 1], z = [1, 2, 3, 4], label = ["A", "B", "C", "D"], text_color = [:black, :black, :black, :red])

data(df) * mapping(:x, :y) * (
    mapping(:z) * visual(Heatmap) +
    mapping(text = :label => verbatim, color = :text_color => verbatim) * visual(Makie.Text)
) |> draw
```

Here the text colors ended up in the heatmap's color scale and were sent through `numbers_to_colors`:

```
MethodError: no method matching numbers_to_colors(::Vector{Symbol}, ::Vector{RGBA{Float32}}, ...)
```

The workaround so far was `=> verbatim => scale(:color2)`, which only helped because it changed the lookup key to one that has no scale attached.

Verbatim values now stay wrapped through scale resolution, which short-circuits on them, and are unwrapped when the `Entry` is built, so the example works as is:

<img width="600" height="450" alt="heatmap with black cell labels and one red one" src="https://github.com/user-attachments/assets/dc16d184-e4b5-4929-b366-59370157920c">
